### PR TITLE
Revision of the Computation of Cost Estimate

### DIFF
--- a/Components/Forms/PreviewPrintQuote.xaml.vb
+++ b/Components/Forms/PreviewPrintQuote.xaml.vb
@@ -41,7 +41,7 @@ Namespace DPC.Components.Forms
             QuoteDate.Text = CostEstimateDetails.CEQuoteDateCache
             QuoteValidityDate.Text = CostEstimateDetails.CEValidUntilDate ' Changed the Cache name while the previous cache variable would be stay
             Subtotal.Text = CostEstimateDetails.CESubTotalCache
-            TotalCost.Text = CostEstimateDetails.CETotalAmountCache
+            TotalCost.Text = CostEstimateDetails.CEGrandTotalCost
             VAT12.Text = CostEstimateDetails.CETotalTaxValueCache
             Delivery.Text = "₱ " & CostEstimateDetails.CEDeliveryCost.ToString("N2")
             itemOrder = CostEstimateDetails.CEQuoteItemsCache
@@ -86,6 +86,7 @@ Namespace DPC.Components.Forms
             End If
 
             If CEtaxSelection Then
+                ' Visibility of the Vat Text
                 VatText.Visibility = Visibility.Collapsed
                 VatValue.Visibility = Visibility.Collapsed
             Else

--- a/data/DataModules/CostEstimateDetails.vb
+++ b/data/DataModules/CostEstimateDetails.vb
@@ -51,6 +51,7 @@
     Public CEDeliveryMobilization = "Not Selected" ' Default Value if doesnt work
     Public CERepresentative As String = "" ' Representative for the cost estimate
     Public CECNIndetifier As String ' Client Identifier for the cost estimate
+    Public CEGrandTotalCost As String ' Grand Total Cost for the cost estimate
 
     Public Sub ClearAllCECache()
         CEQuoteNumberCache = ""
@@ -93,18 +94,21 @@
         CEWarehouseIDCache = ""
         CEWarehouseNameCache = ""
 
-        CETerm1 = ""
-        CETerm2 = ""
-        CETerm3 = ""
-        CETerm4 = ""
-        CETerm5 = ""
-        CETerm6 = ""
-        CETerm7 = ""
+        CETerm1 = "50% upon ordering"
+        CETerm2 = "30% upon delivery"
+        CETerm3 = "20% upon completion"
+        CETerm4 = "Progress billing remaining balance (for bulk orders)"
+        CETerm5 = "Order will process upon clearance of cheque"
+        CETerm6 = "Any additional orders will be charged seperately"
+        CETerm7 = "No return after installation"
         CETerm8 = ""
-        CETerm9 = ""
-        CETerm10 = ""
-        CETerm11 = ""
+        CETerm9 = "Additional delivery charges"
+        CETerm10 = "Please indicate lead time for installation"
+        CETerm11 = "We will have a site inscpetions prior to installation"
         CETerm12 = ""
+        CETerm13 = "" ' Before Terms
+        CETerm14 = "" ' During Terms
+        CETerm15 = "" ' After Terms
 
         CETotalCostDelivery = 0D
         CEDeliveryCost = 0D


### PR DESCRIPTION
- Computation for Inclusive 
For Vat12 = (Subtotal + Installation + Delivery) * 0.12
For Total Cost = Subtotal + Installation + Delivery + Vat12%

- Computation for exclusive
For Total Cost = Subtotal + Installation + Delivery

- Revert of taxselection where vat12% will collapse if the tax selection is tax exclusive
- Fixed the bug in the cost estimate form (Sales > New Cost Estimate) where the tax value only applies to a single item after changing multiple items
- Added calculation to the Generate Cost Estimate in initialization
- Fixed the bugs in the payment terms where every new payment after the previous generated cost estimate, the default value will become empty 
- Reduced the function of the computation of the cost lines of code in the Generated Cost Estimate Receipt

** Note that this is not the final and more bugs may be found in this module, so keep an eye on it and report it to the administrator **