### PR TITLE
Feature/computation in ce revision

### DIFF
--- a/Views/Sales/Quotes/CostEstimate.xaml.vb
+++ b/Views/Sales/Quotes/CostEstimate.xaml.vb
@@ -103,61 +103,58 @@ Namespace DPC.Views.Sales.Quotes
                 cmbTerms.Text = CostEstimateDetails.CEpaymentTerms
             End If
 
-            If CEtaxSelection Then
-                ' Tax Exclusive: Add VAT to total cost
-                VatText.Visibility = Visibility.Collapsed
-                VatValue.Visibility = Visibility.Collapsed
-                VAT12.Text = "₱ 0.00"
-                If String.IsNullOrWhiteSpace(CostEstimateDetails.CEremarksTxt) OrElse remarksBox.Text = "Tax Inclusive." OrElse remarksBox.Text = "Tax Exclusive." Then
-                    remarksBox.Text = "Tax Exclusive."
-                End If
-                Dim totalAmount As Decimal = 0
-                Dim rawTotal = CostEstimateDetails.CETotalAmountCache.Trim().Replace("₱", "").Replace(",", "").Trim()
-                If Decimal.TryParse(rawTotal, totalAmount) Then
-                    Dim totalCostValue As Decimal = totalAmount + installationFee + deliveryCost
-                    If TotalCost IsNot Nothing Then
-                        TotalCost.Text = "₱ " & totalCostValue.ToString("F2")
-                        CostEstimateDetails.CETotalAmountCache = "₱ " & totalAmount.ToString("F2")
-                    Else
-                        Debug.WriteLine("TotalCost is Nothing")
-                    End If
-                Else
-                    Debug.WriteLine("Failed to parse CETotalAmountCache: '{rawTotal}'")
-                    If TotalCost IsNot Nothing Then
-                        TotalCost.Text = "₱ 0.00"
-                    End If
-                End If
-            Else
-                ' Tax Inclusive: Do NOT add VAT to total cost
+            If Not CEtaxSelection Then
+                ' Tax Inclusive
                 VatText.Visibility = Visibility.Visible
                 VatValue.Visibility = Visibility.Visible
                 If String.IsNullOrWhiteSpace(CostEstimateDetails.CEremarksTxt) OrElse remarksBox.Text = "Tax Inclusive." OrElse remarksBox.Text = "Tax Exclusive." Then
                     remarksBox.Text = "Tax Inclusive."
                 End If
-                Dim totalAmount As Decimal = 0
-                Dim rawTotal = CostEstimateDetails.CETotalAmountCache.Trim().Replace("₱", "").Replace(",", "").Trim()
-                If Decimal.TryParse(rawTotal, totalAmount) Then
-                    Dim totalCostValue As Decimal = totalAmount + installationFee + deliveryCost
-                    If TotalCost IsNot Nothing Then
-                        TotalCost.Text = "₱ " & totalCostValue.ToString("F2")
-                        CostEstimateDetails.CETotalAmountCache = "₱ " & totalCostValue.ToString("F2")
-                    Else
-                        Debug.WriteLine("TotalCost is Nothing")
-                    End If
-                    ' Show VAT for display only, do not add to total cost
-                    Dim vatDisplayValue As Decimal = totalAmount * 0.12D
-                    If VAT12 IsNot Nothing Then
-                        VAT12.Text = "₱ " & vatDisplayValue.ToString("F2")
-                        CostEstimateDetails.CETotalTaxValueCache = VAT12.Text
-                    End If
+
+                ' Calculate Total Amount Before VAT
+                Dim totalAmountBeforeVAT As Decimal = 0
+                Dim rawSubtotal = Subtotal.Text.Replace("₱", "").Trim().Replace(",", "").Trim()
+                If Decimal.TryParse(rawSubtotal, totalAmountBeforeVAT) Then
+                    totalAmountBeforeVAT += installationFee + deliveryCost
+
+                    ' Calculate VAT
+                    Dim vatAmount As Decimal = totalAmountBeforeVAT * 0.12D
+                    VAT12.Text = "₱ " & vatAmount.ToString("F2")
+                    CostEstimateDetails.CETotalTaxValueCache = VAT12.Text
+
+                    ' Calculate Total Cost
+                    Dim totalCostValue As Decimal = totalAmountBeforeVAT + vatAmount
+                    TotalCost.Text = "₱ " & totalCostValue.ToString("F2")
+                    CostEstimateDetails.CETotalAmountCache = "₱ " & totalCostValue.ToString("F2")
                 Else
-                    Debug.WriteLine("Failed to parse CETotalAmountCache: '{rawTotal}'")
-                    If TotalCost IsNot Nothing Then
-                        TotalCost.Text = "₱ 0.00"
-                    End If
-                    If VAT12 IsNot Nothing Then
-                        VAT12.Text = "₱ 0.00"
-                    End If
+                    Debug.WriteLine("Failed to parse Subtotal.Text: '{rawSubtotal}'")
+                    TotalCost.Text = "₱ 0.00"
+                    VAT12.Text = "₱ 0.00"
+                End If
+            Else
+                ' Tax Exclusive
+                VatText.Visibility = Visibility.Collapsed
+                VatValue.Visibility = Visibility.Collapsed
+                If String.IsNullOrWhiteSpace(CostEstimateDetails.CEremarksTxt) OrElse remarksBox.Text = "Tax Inclusive." OrElse remarksBox.Text = "Tax Exclusive." Then
+                    remarksBox.Text = "Tax Exclusive."
+                End If
+
+                ' Calculate Total Cost
+                Dim totalCostValue As Decimal = 0
+                Dim rawSubtotal = Subtotal.Text.Replace("₱", "").Trim().Replace(",", "").Trim()
+                If Decimal.TryParse(rawSubtotal, totalCostValue) Then
+                    totalCostValue += installationFee + deliveryCost
+
+                    ' VAT is 0 for exclusive
+                    VAT12.Text = "₱ 0.00"
+                    CostEstimateDetails.CETotalTaxValueCache = VAT12.Text
+
+                    TotalCost.Text = "₱ " & totalCostValue.ToString("F2")
+                    CostEstimateDetails.CETotalAmountCache = "₱ " & totalCostValue.ToString("F2")
+                Else
+                    Debug.WriteLine("Failed to parse Subtotal.Text: '{rawSubtotal}'")
+                    TotalCost.Text = "₱ 0.00"
+                    VAT12.Text = "₱ 0.00"
                 End If
             End If
 
@@ -266,11 +263,12 @@ Namespace DPC.Views.Sales.Quotes
             ' Calculate total cost
             Dim totalCostVal As Decimal
             If CEtaxSelection Then
-                ' Tax Exclusive: Add VAT to total cost
-                totalCostVal = baseAmount + vatAmount
-            Else
+
                 ' Tax Inclusive: Do NOT add VAT to total cost
                 totalCostVal = baseAmount
+            Else
+                ' Tax Exclusive: Add VAT to total cost
+                totalCostVal = baseAmount + vatAmount
             End If
             Debug.WriteLine($"Computed Total: {totalCostVal}")
 

--- a/Views/Sales/Quotes/CostEstimate.xaml.vb
+++ b/Views/Sales/Quotes/CostEstimate.xaml.vb
@@ -45,7 +45,7 @@ Namespace DPC.Views.Sales.Quotes
             If Decimal.TryParse(CostEstimateDetails.CEInstallation, installationFee) Then
                 Installation.Text = "₱ " & installationFee.ToString("N2")
             Else
-                Installation.Text = "₱ 0.00" ' fallback value if parsing fails
+                Installation.Text = "₱ 0.00"
                 installationFee = 0D
             End If
 
@@ -53,7 +53,7 @@ Namespace DPC.Views.Sales.Quotes
             If Decimal.TryParse(CostEstimateDetails.CEDeliveryCost, deliveryCost) Then
                 Delivery.Text = "₱ " & deliveryCost.ToString("N2")
             Else
-                Delivery.Text = "₱ 0.00" ' fallback value if parsing fails
+                Delivery.Text = "₱ 0.00"
                 deliveryCost = 0D
             End If
 
@@ -119,13 +119,13 @@ Namespace DPC.Views.Sales.Quotes
 
                     ' Calculate VAT
                     Dim vatAmount As Decimal = totalAmountBeforeVAT * 0.12D
-                    VAT12.Text = "₱ " & vatAmount.ToString("F2")
+                    VAT12.Text = "₱ " & vatAmount.ToString("N2")
                     CostEstimateDetails.CETotalTaxValueCache = VAT12.Text
 
                     ' Calculate Total Cost
                     Dim totalCostValue As Decimal = totalAmountBeforeVAT + vatAmount
-                    TotalCost.Text = "₱ " & totalCostValue.ToString("F2")
-                    CostEstimateDetails.CETotalAmountCache = "₱ " & totalCostValue.ToString("F2")
+                    TotalCost.Text = "₱ " & totalCostValue.ToString("N2")
+                    CostEstimateDetails.CETotalAmountCache = "₱ " & totalCostValue.ToString("N2")
                 Else
                     Debug.WriteLine("Failed to parse Subtotal.Text: '{rawSubtotal}'")
                     TotalCost.Text = "₱ 0.00"
@@ -149,8 +149,8 @@ Namespace DPC.Views.Sales.Quotes
                     VAT12.Text = "₱ 0.00"
                     CostEstimateDetails.CETotalTaxValueCache = VAT12.Text
 
-                    TotalCost.Text = "₱ " & totalCostValue.ToString("F2")
-                    CostEstimateDetails.CETotalAmountCache = "₱ " & totalCostValue.ToString("F2")
+                    TotalCost.Text = "₱ " & totalCostValue.ToString("N2")
+                    CostEstimateDetails.CETotalAmountCache = "₱ " & totalCostValue.ToString("N2")
                 Else
                     Debug.WriteLine("Failed to parse Subtotal.Text: '{rawSubtotal}'")
                     TotalCost.Text = "₱ 0.00"
@@ -173,11 +173,11 @@ Namespace DPC.Views.Sales.Quotes
                 Dim linePriceFormatted As String = linePrice.ToString("N2")
 
                 itemDataSource.Add(New OrderItems With {
-                    .Quantity = item("Quantity"),
-                    .Description = item("ProductName"),
-                    .UnitPrice = $"₱ {rateFormatted}",
-                    .LinePrice = $"₱ {linePriceFormatted}"
-                })
+        .Quantity = item("Quantity"),
+        .Description = item("ProductName"),
+        .UnitPrice = $"₱ {rateFormatted}",
+        .LinePrice = $"₱ {linePriceFormatted}"
+    })
             Next
 
             ' Display the data in the DataGrid
@@ -256,7 +256,7 @@ Namespace DPC.Views.Sales.Quotes
 
             ' Calculate VAT12 for display only
             Dim vatAmount As Decimal = baseAmount * 0.12D
-            VAT12.Text = "₱ " & vatAmount.ToString("F2")
+            VAT12.Text = "₱ " & vatAmount.ToString("N2")
             CostEstimateDetails.CETotalTaxValueCache = VAT12.Text
             Debug.WriteLine($"Computed VAT: {vatAmount}")
 

--- a/Views/Sales/Quotes/NewQuote.xaml
+++ b/Views/Sales/Quotes/NewQuote.xaml
@@ -429,7 +429,7 @@
                                     <DataGridTextColumn Header="Item Name" Binding="{Binding ItemName}" Width="150"/>
                                     <DataGridTextColumn Header="Quantity" Binding="{Binding Quantity}" Width="80"/>
                                     <DataGridTextColumn Header="Unit Price" Binding="{Binding Rate}" Width="90"/>
-                                    <DataGridTextColumn Header="Tax (%)" Binding="{Binding TaxtPercent}" Width="93"/>
+                                    <DataGridTextColumn Header="Tax (%)" x:Name="TaxHeader" Binding="{Binding TaxtPercent}" Width="93"/>
                                     <DataGridTextColumn Header="Tax" Binding="{Binding TaxValue}" Width="50"/>
                                     <DataGridTextColumn Header="Discount (%)" Binding="{Binding DiscountPercent}" Width="120"/>
                                     <DataGridTextColumn Header="Discount" Binding="{Binding Discount}" Width="75"/>

--- a/Views/Sales/Quotes/NewQuote.xaml.vb
+++ b/Views/Sales/Quotes/NewQuote.xaml.vb
@@ -171,6 +171,8 @@ Namespace DPC.Views.Sales.Quotes
 
             cmbCostEstimateValidty.Text = CostEstimateDetails.CEValidUntilDate
 
+            TaxHeader.Header = If(_TaxSelection, "Tax(%)", "Tax(12%)")
+
             Debug.WriteLine($"Tax Selection - {_TaxSelection}")
             Debug.WriteLine($"Tax Value In Quote Properties - {_SelectedTax}")
         End Sub
@@ -378,14 +380,16 @@ Namespace DPC.Views.Sales.Quotes
                 If kvp.Key.StartsWith("txtTaxPercent_") Then
                     If _TaxSelection Then
                         ' Exclusive: Allow user to edit and clear the value
-                        kvp.Value.Text = "" ' Let user type any percent
+                        kvp.Value.Text = "0" ' Let user type any percent
                         kvp.Value.IsReadOnly = False
                         CEtaxSelection = True
+                        TaxHeader.Header = "Tax(%)"
                     Else
                         ' Inclusive: Set to 12 and make it readonly
+                        kvp.Value.Text = ""
                         kvp.Value.IsReadOnly = True
                         CEtaxSelection = False
-                        kvp.Value.Text = "0"
+                        TaxHeader.Header = "Tax(12%)"
                     End If
                 End If
             Next
@@ -831,7 +835,7 @@ Namespace DPC.Views.Sales.Quotes
         ' Tax Percent Textbox
         Private Function CreateTaxPercentBox(rowIndex As Integer) As Border
             ' Set the default value to "12" if the tax is inclusive
-            Dim defaultTaxPercent As String = If(Not _TaxSelection, "12", "")
+            Dim defaultTaxPercent As String = If(Not CEtaxSelection, "", "0")
 
             ' Create the textbox with the default value and readonly behavior
             Dim box = CreateInputBox(defaultTaxPercent, 60, Not _TaxSelection, $"txtTaxPercent_{rowIndex}")
@@ -958,7 +962,7 @@ Namespace DPC.Views.Sales.Quotes
                 If taxPercentBox IsNot Nothing Then
                     If Not _TaxSelection Then
                         ' Inclusive: set to default and lock
-                        taxPercentBox.Text = (_SelectedTax * 100).ToString()
+                        ' taxPercentBox.Text = 12 ' Removed for testing 
                         taxPercentBox.IsReadOnly = True
                     Else
                         ' Exclusive: let user type

--- a/Views/Sales/Quotes/NewQuote.xaml.vb
+++ b/Views/Sales/Quotes/NewQuote.xaml.vb
@@ -966,7 +966,7 @@ Namespace DPC.Views.Sales.Quotes
                         taxPercentBox.IsReadOnly = True
                     Else
                         ' Exclusive: let user type
-                        taxPercentBox.Text = ""
+                        taxPercentBox.Text = "0"
                         taxPercentBox.IsReadOnly = False
                     End If
                 End If
@@ -1031,17 +1031,17 @@ Namespace DPC.Views.Sales.Quotes
 
                 ' Update txtTaxValueBox and amount value
                 Dim taxValueBoxVal = FindTextBoxByName($"txtTaxValue_{rowIndex}")
-                taxValueBox.Text = taxValue.ToString("F2")
+                taxValueBox.Text = taxValue.ToString("N2")
                 Dim amountBoxVal = FindTextBoxByName($"txtAmount_{rowIndex}")
-                amountBox.Text = "₱" & amountBeforeDiscount.ToString("F2")
+                amountBox.Text = "₱" & amountBeforeDiscount.ToString("N2")
             End If
 
             Dim discountValue = amountBeforeDiscount * (discountPercent / 100)
             Dim finalAmount = amountBeforeDiscount - discountValue
 
-            If taxValueBox IsNot Nothing Then taxValueBox.Text = taxValue.ToString("F2")
-            If discountBox IsNot Nothing Then discountBox.Text = discountValue.ToString("F2")
-            amountBox.Text = "₱" & finalAmount.ToString("F2")
+            If taxValueBox IsNot Nothing Then taxValueBox.Text = taxValue.ToString("N2")
+            If discountBox IsNot Nothing Then discountBox.Text = discountValue.ToString("N2")
+            amountBox.Text = "₱" & finalAmount.ToString("N2")
 
             Debug.WriteLine($"[Row {rowIndex}] Base: {baseAmount}, Tax: {taxValue}, Discount: {discountValue}, Total: {finalAmount}")
 
@@ -1086,7 +1086,7 @@ Namespace DPC.Views.Sales.Quotes
             Next
 
             ' Update the grand total display
-            txtGrandTotal.Text = "₱" & grandTotal.ToString("F2")
+            txtGrandTotal.Text = "₱" & grandTotal.ToString("N2")
         End Sub
 
         ' This function is for updating the value of tax whenever there is changes
@@ -1110,7 +1110,7 @@ Namespace DPC.Views.Sales.Quotes
             Next
 
             ' Example output target: you should declare this in your XAML like you did with txtGrandTotal
-            txtTotalTax.Text = "₱" & totalTax.ToString("F2")
+            txtTotalTax.Text = "₱" & totalTax.ToString("N2")
         End Sub
 
         Public Sub UpdateTotalDiscount()
@@ -1131,7 +1131,7 @@ Namespace DPC.Views.Sales.Quotes
                 End If
             Next
 
-            txtTotalDiscount.Text = "₱" & totalDiscount.ToString("F2")
+            txtTotalDiscount.Text = "₱" & totalDiscount.ToString("N2")
         End Sub
 
 


### PR DESCRIPTION
- Added Visual text in the datagrid column header if the user selected inclusive (Display "Tax (12%)") or exclusive (Display "Tax (%)").
- Revise the computation for computing the total cost after generating the cost estimate with the following computation.
- In Tax Inclusive.

Vat 12% = (Subtotal + Installation + Delivery) * 12%
Total Cost = Subtotal + Installation + Delivery + Vat 12%

- In Tax Exclusive.
- Feature the VAT 12% if you selected exclusive, will automatically not be counted.

Total Cost = Subtotal + Installation + Delivery

- Added the comma when the digits of a number increase.
- Possible bugs may occur, and the computation might be a little inaccurate, so keep an eye on it.