### PR TITLE
feature/manage-products -rev2

### DIFF
--- a/Views/Stocks/ItemManager/ProductManager/ManageProducts.xaml
+++ b/Views/Stocks/ItemManager/ProductManager/ManageProducts.xaml
@@ -317,7 +317,7 @@
                         <Style TargetType="DataGridRow">
                             <Setter Property="Margin" Value="0,2,0,2"/>
                             <Setter Property="Padding" Value="0"/>
-                            <Setter Property="MinHeight" Value="50"/>
+                            <Setter Property="MinHeight" Value="85"/>
                             <Style.Triggers>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter Property="Background" Value="#EEF2FA"/>
@@ -352,15 +352,16 @@
                                             CellStyle="{StaticResource CenteredCellStyle}"/>
 
                         <!-- Product Image with rounded clipping -->
-                        <DataGridTemplateColumn Header="Image" Width="80">
+                        <DataGridTemplateColumn Header="Image" Width="120" MinWidth="120">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
-                                    <Border CornerRadius="8" Width="60" Height="60" Margin="4"
-                                            Background="#F0F0F0" BorderBrush="#E0E0E0" BorderThickness="1">
+                                    <Border CornerRadius="8" Width="80" Height="80" Margin="8"
+                                            Background="#F0F0F0" BorderBrush="#E0E0E0" BorderThickness="1"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center">
                                         <Border.Clip>
-                                            <RectangleGeometry RadiusX="8" RadiusY="8" Rect="0,0,60,60"/>
+                                            <RectangleGeometry RadiusX="8" RadiusY="8" Rect="0,0,80,80"/>
                                         </Border.Clip>
-                                        <Image Source="{Binding ImageSource}" Width="60" Height="60" Stretch="UniformToFill"/>
+                                        <Image Source="{Binding ImageSource}" Width="80" Height="80" Stretch="UniformToFill"/>
                                     </Border>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
UI Changes:

Fix the image where it is being cut. Adjusted the size of the product image for the user to be able to see it fully and clearly without cut.

- Adjusted size of image from 70 x 70 to 80 x 80
- Adjusted column width from 100 to 120 