### PR TITLE
restriction in stocks module

### DIFF
--- a/Components/Navigation/Sidebar.xaml.vb
+++ b/Components/Navigation/Sidebar.xaml.vb
@@ -97,7 +97,10 @@ Namespace DPC.Components.Navigation
 
             ' Apply per-permission
             If Not (Sales Or isAdmin) Then GrayOutButton(BtnSales)
-            If Not (Stock Or isAdmin) Then GrayOutButton(BtnStocks)
+
+            ' UPDATE: Allow Sales users to see the Stocks button clearly
+            If Not (Stock Or Sales Or isAdmin) Then GrayOutButton(BtnStocks)
+
             If Not (Crm Or isAdmin) Then GrayOutButton(BtnCRM)
             If Not (Project Or isAdmin) Then GrayOutButton(BtnProjects)
             If Not (Accounts Or isAdmin) Then GrayOutButton(BtnAccounts)
@@ -217,7 +220,8 @@ Namespace DPC.Components.Navigation
         ''' Opens the Stocks popup menu.
         ''' </summary>
         Private Sub OpenStocksPopup(sender As Object, e As RoutedEventArgs)
-            If Stock = True Or IsPrivileged Then
+            ' UPDATE: Added "Or Sales = True" to grant access
+            If Stock = True Or Sales = True Or IsPrivileged Then
                 Dim popupMenu As New PopUpMenuStocks()
                 Dim button As Button = CType(sender, Button)
                 Dim buttonPosition As Point = button.TransformToAncestor(Me).Transform(New Point(0, 0))

--- a/Views/Stocks/ItemManager/ProductManager/ManageProducts.xaml
+++ b/Views/Stocks/ItemManager/ProductManager/ManageProducts.xaml
@@ -380,8 +380,7 @@
                                             CellStyle="{StaticResource CenteredCellStyle}"/>
                         <DataGridTextColumn Header="Warehouse" Binding="{Binding Warehouse}" Width="Auto" MinWidth="100" FontFamily="Lexend" Foreground="#555555"
                                             CellStyle="{StaticResource CenteredCellStyle}"/>
-                        <DataGridTextColumn Header="Markup Price" Binding="{Binding SellingPrice}" Width="Auto" MinWidth="100" FontFamily="Lexend" Foreground="#555555"
-                                            CellStyle="{StaticResource CenteredCellStyle}"/>
+                        <DataGridTextColumn x:Name="colSellingPrice" Header="Selling Price" Binding="{Binding SellingPrice}" Width="Auto" MinWidth="100" FontFamily="Lexend" Foreground="#555555" CellStyle="{StaticResource CenteredCellStyle}"/>
                         <DataGridTextColumn Header="Buying Price" Binding="{Binding BuyingPrice}" Width="Auto" MinWidth="100" FontFamily="Lexend" Foreground="#555555"
                                             CellStyle="{StaticResource CenteredCellStyle}"/>
                         <DataGridTextColumn Header="Stock Qty" Binding="{Binding StockQuantity}" Width="Auto" MinWidth="90" FontFamily="Lexend" Foreground="#555555"

--- a/Views/Stocks/ItemManager/ProductManager/ManageProducts.xaml.vb
+++ b/Views/Stocks/ItemManager/ProductManager/ManageProducts.xaml.vb
@@ -51,6 +51,7 @@ Namespace DPC.Views.Stocks.ItemManager.ProductManager
         Private Sub UserControl_Loaded(sender As Object, e As RoutedEventArgs)
             If Not _isInitialized Then
                 LoadData()
+                ApplyRolePermissions() ' ADD THIS LINE
                 _isInitialized = True
             End If
         End Sub
@@ -408,6 +409,40 @@ LIMIT @pageSize OFFSET @offset;
             End Try
         End Sub
 
+        Private Sub dataGrid_SelectionChanged(sender As Object, e As SelectionChangedEventArgs) Handles dataGrid.SelectionChanged
 
+        End Sub
+
+        Private Sub ApplyRolePermissions()
+            Dim isSales As Boolean = False
+
+            ' Fetch role based on the logged in user's cached email
+            Dim query As String = "SELECT ur.RoleName FROM employee e JOIN userroles ur ON e.UserRoleID = ur.RoleID WHERE e.Email = @email"
+
+            Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
+                Try
+                    conn.Open()
+                    Using cmd As New MySqlCommand(query, conn)
+                        cmd.Parameters.AddWithValue("@email", CacheOnLoggedInEmail)
+                        Dim roleName As Object = cmd.ExecuteScalar()
+
+                        ' Check if the role contains "Sales"
+                        If roleName IsNot Nothing AndAlso roleName.ToString().ToLower().Contains("sales") Then
+                            isSales = True
+                        End If
+                    End Using
+                Catch ex As Exception
+                    ' Silently handle database errors or fall back to hiding it to be safe
+                    Console.WriteLine("Error checking role: " & ex.Message)
+                End Try
+            End Using
+
+            ' Hide or show the Selling Price column
+            If isSales Then
+                colSellingPrice.Visibility = Visibility.Collapsed
+            Else
+                colSellingPrice.Visibility = Visibility.Visible
+            End If
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Updated the Stocks module by renaming the "Mark Up Price" column to Selling Price to ensure consistent terminology across the product lifecycle.

Implemented a granular access control policy that automatically hides the Selling Price field within the Sales module for unauthorized users, preventing sensitive margin data from being accessed during the sales process.