### PR TITLE
Feature/dashboard year picker apr08

### DIFF
--- a/Views/Dashboard/Dashboard.xaml
+++ b/Views/Dashboard/Dashboard.xaml
@@ -109,10 +109,11 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
                         <!-- Card 1: Today Invoices -->
-                        <Border Background="White" CornerRadius="10" Margin="10" Width="170" Grid.Column="0">
+                        <Border Background="White" CornerRadius="10" Margin="5" HorizontalAlignment="Stretch" Grid.Column="0">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10">
                                 <Grid Width="50" Height="50" Margin="0,0,0,10">
                                     <Ellipse Fill="#f0f0f0"/>
@@ -128,7 +129,7 @@
                         </Border>
 
                         <!-- Card 2: This Month Invoices -->
-                        <Border Background="White" CornerRadius="10" Margin="10" Width="170"  Grid.Column="1">
+                        <Border Background="White" CornerRadius="10" Margin="5" HorizontalAlignment="Stretch" Grid.Column="1">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10">
                                 <Grid Width="50" Height="50" Margin="0,0,0,10">
                                     <Ellipse Fill="#f0f0f0"/>
@@ -144,7 +145,7 @@
                         </Border>
 
                         <!-- Card 3: Today Sales -->
-                        <Border Background="White" CornerRadius="10" Margin="10" Width="170" Grid.Column="2">
+                        <Border Background="White" CornerRadius="10" Margin="5" HorizontalAlignment="Stretch" Grid.Column="2">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10">
                                 <Grid Width="50" Height="50" Margin="0,0,0,10">
                                     <Ellipse Fill="#f0f0f0"/>
@@ -161,7 +162,7 @@
                         </Border>
 
                         <!-- Card 4: This Month Sales -->
-                        <Border Background="White" CornerRadius="10" Margin="10" Width="170" Grid.Column="3">
+                        <Border Background="White" CornerRadius="10" Margin="5" HorizontalAlignment="Stretch" Grid.Column="3">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10">
                                 <Grid Width="50" Height="50" Margin="0,0,0,10">
                                     <Ellipse Fill="#f0f0f0"/>
@@ -173,6 +174,22 @@
                                 </Grid>
                                 <TextBlock Text="This Month Sales" FontWeight="SemiBold" FontSize="12" HorizontalAlignment="Center" FontFamily="Lexend" />
                                 <TextBlock x:Name="TxtMonthSales" Text="+?0.00" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center" FontFamily="Lexend" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Card 5: This Year's Sales -->
+                        <Border Background="White" CornerRadius="10" Margin="5" HorizontalAlignment="Stretch" Grid.Column="4">
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10">
+                                <Grid Width="50" Height="50" Margin="0,0,0,10">
+                                    <Ellipse Fill="#f0f0f0"/>
+                                    <materialDesign:PackIcon Kind="Finance"
+                                     Width="24" Height="24"
+                                     Foreground="Black"
+                                     HorizontalAlignment="Center"
+                                     VerticalAlignment="Center"/>
+                                </Grid>
+                                <TextBlock Text="This Year's Sales" FontWeight="SemiBold" FontSize="12" HorizontalAlignment="Center" FontFamily="Lexend" />
+                                <TextBlock x:Name="TxtYearlySales" Text="+?0.00" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center" FontFamily="Lexend" />
                             </StackPanel>
                         </Border>
                     </Grid>

--- a/Views/Dashboard/Dashboard.xaml
+++ b/Views/Dashboard/Dashboard.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="DPC.Views.Dashboard.Dashboard"
+﻿<UserControl x:Class="DPC.Views.Dashboard.Dashboard"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -188,8 +188,29 @@
                                      HorizontalAlignment="Center"
                                      VerticalAlignment="Center"/>
                                 </Grid>
-                                <TextBlock Text="This Year's Sales" FontWeight="SemiBold" FontSize="12" HorizontalAlignment="Center" FontFamily="Lexend" />
-                                <TextBlock x:Name="TxtYearlySales" Text="+?0.00" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center" FontFamily="Lexend" />
+
+                                <!-- Year Navigator -->
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                    <Button x:Name="BtnPrevYear" Content="◀"
+                    Style="{StaticResource MaterialDesignFlatButton}"
+                    Padding="2" MinWidth="0" Height="20"
+                    Click="BtnPrevYear_Click"/>
+                                    <TextBox x:Name="TxtSelectedYear"
+         Width="48" TextAlignment="Center"
+         BorderThickness="0" Background="Transparent"
+         FontFamily="Lexend" FontWeight="SemiBold" FontSize="12"
+         VerticalAlignment="Center"
+         KeyDown="TxtSelectedYear_KeyDown"/>
+                                    <Button x:Name="BtnNextYear" Content="▶"
+                    Style="{StaticResource MaterialDesignFlatButton}"
+                    Padding="2" MinWidth="0" Height="20"
+                    Click="BtnNextYear_Click"/>
+                                </StackPanel>
+
+                                <TextBlock Text="Year's Sales" FontWeight="SemiBold" FontSize="12"
+                   HorizontalAlignment="Center" FontFamily="Lexend"/>
+                                <TextBlock x:Name="TxtYearlySales" Text="+0.00" FontWeight="Bold"
+                   FontSize="20" HorizontalAlignment="Center" FontFamily="Lexend"/>
                             </StackPanel>
                         </Border>
                     </Grid>

--- a/Views/Dashboard/Dashboard.xaml.vb
+++ b/Views/Dashboard/Dashboard.xaml.vb
@@ -20,16 +20,10 @@ Namespace DPC.Views.Dashboard
                 Dim monthSales As Decimal = BillingController.GetThisMonthTotalSales()
                 Dim yearlySales As Decimal = BillingController.GetThisYearTotalSales()
 
-                ' TEMPORARY DEBUG - remove after fixing
-                MessageBox.Show($"Today: {todaySales} | Month: {monthSales} | Year: {yearlySales}", "Debug Sales")
-
                 TxtTodaySales.Text = "+" & todaySales.ToString("N2")
                 TxtMonthSales.Text = "+" & monthSales.ToString("N2")
                 TxtYearlySales.Text = "+" & yearlySales.ToString("N2")
             Catch ex As Exception
-                ' TEMPORARY DEBUG - shows actual error
-                MessageBox.Show("Error: " & ex.Message, "Debug Error")
-                Debug.WriteLine("Error loading sales data: " & ex.Message)
             End Try
         End Sub
 

--- a/Views/Dashboard/Dashboard.xaml.vb
+++ b/Views/Dashboard/Dashboard.xaml.vb
@@ -5,12 +5,19 @@ Namespace DPC.Views.Dashboard
     Partial Public Class Dashboard
         Inherits UserControl
 
+        Private _selectedYear As Integer = DateTime.Now.Year
+        Private _earliestYear As Integer = DateTime.Now.Year
+
         Public Sub New()
             InitializeComponent()
             AddHandler Loaded, AddressOf Dashboard_Loaded
         End Sub
 
         Private Sub Dashboard_Loaded(sender As Object, e As RoutedEventArgs)
+            _earliestYear = BillingController.GetEarliestSalesYear()
+            _selectedYear = DateTime.Now.Year
+            TxtSelectedYear.Text = _selectedYear.ToString()
+            AddHandler TxtSelectedYear.KeyDown, AddressOf TxtSelectedYear_KeyDown
             LoadSalesData()
         End Sub
 
@@ -18,15 +25,45 @@ Namespace DPC.Views.Dashboard
             Try
                 Dim todaySales As Decimal = BillingController.GetTodayTotalSales()
                 Dim monthSales As Decimal = BillingController.GetThisMonthTotalSales()
-                Dim yearlySales As Decimal = BillingController.GetThisYearTotalSales()
+                Dim yearlySales As Decimal = BillingController.GetSalesByYear(_selectedYear)
 
                 TxtTodaySales.Text = "+" & todaySales.ToString("N2")
                 TxtMonthSales.Text = "+" & monthSales.ToString("N2")
                 TxtYearlySales.Text = "+" & yearlySales.ToString("N2")
+
+                ' Disable ▶ if already at current year
+                BtnNextYear.IsEnabled = (_selectedYear < DateTime.Now.Year)
+                ' Disable ◀ if at or before earliest record (with 5yr buffer)
+                BtnPrevYear.IsEnabled = (_selectedYear > _earliestYear - 5)
             Catch ex As Exception
+                Debug.WriteLine("LoadSalesData error: " & ex.Message)
             End Try
         End Sub
 
+        Private Sub BtnPrevYear_Click(sender As Object, e As RoutedEventArgs)
+            _selectedYear -= 1
+            TxtSelectedYear.Text = _selectedYear.ToString()
+            LoadSalesData()
+        End Sub
+
+        Private Sub BtnNextYear_Click(sender As Object, e As RoutedEventArgs)
+            _selectedYear += 1
+            TxtSelectedYear.Text = _selectedYear.ToString()
+            LoadSalesData()
+        End Sub
+
+        Private Sub TxtSelectedYear_KeyDown(sender As Object, e As KeyEventArgs)
+            If e.Key = Key.Return Then
+                Dim parsed As Integer
+                If Integer.TryParse(TxtSelectedYear.Text, parsed) AndAlso parsed > 1900 AndAlso parsed <= DateTime.Now.Year + 10 Then
+                    _selectedYear = parsed
+                    LoadSalesData()
+                Else
+                    ' Reset to last valid year if bad input
+                    TxtSelectedYear.Text = _selectedYear.ToString()
+                End If
+            End If
+        End Sub
 
     End Class
 End Namespace

--- a/Views/Dashboard/Dashboard.xaml.vb
+++ b/Views/Dashboard/Dashboard.xaml.vb
@@ -18,10 +18,17 @@ Namespace DPC.Views.Dashboard
             Try
                 Dim todaySales As Decimal = BillingController.GetTodayTotalSales()
                 Dim monthSales As Decimal = BillingController.GetThisMonthTotalSales()
+                Dim yearlySales As Decimal = BillingController.GetThisYearTotalSales()
+
+                ' TEMPORARY DEBUG - remove after fixing
+                MessageBox.Show($"Today: {todaySales} | Month: {monthSales} | Year: {yearlySales}", "Debug Sales")
 
                 TxtTodaySales.Text = "+" & todaySales.ToString("N2")
                 TxtMonthSales.Text = "+" & monthSales.ToString("N2")
+                TxtYearlySales.Text = "+" & yearlySales.ToString("N2")
             Catch ex As Exception
+                ' TEMPORARY DEBUG - shows actual error
+                MessageBox.Show("Error: " & ex.Message, "Debug Error")
                 Debug.WriteLine("Error loading sales data: " & ex.Message)
             End Try
         End Sub

--- a/data/Controllers/BIllingController.vb
+++ b/data/Controllers/BIllingController.vb
@@ -318,5 +318,24 @@ Namespace DPC.Data.Controllers
             End Try
         End Function
 
+        '' GetThisYearTotalSales()
+        Public Shared Function GetThisYearTotalSales() As Decimal
+            Try
+                Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
+                    conn.Open()
+                    Dim query As String = "SELECT COALESCE(SUM(CAST(REPLACE(REPLACE(totalAmount, '₱', ''), ',', '') AS DECIMAL(15,2))), 0) 
+                           FROM walkinbilling 
+                           WHERE YEAR(dateAdded) = YEAR(NOW())"
+                    Using cmd As New MySqlCommand(query, conn)
+                        Dim result = cmd.ExecuteScalar()
+                        Return If(result Is DBNull.Value OrElse result Is Nothing, 0D, Convert.ToDecimal(result))
+                    End Using
+                End Using
+            Catch ex As Exception
+                Debug.WriteLine("Error in GetThisYearTotalSales: " & ex.Message)
+                Return 0D
+            End Try
+        End Function
+
     End Class
 End Namespace

--- a/data/Controllers/BIllingController.vb
+++ b/data/Controllers/BIllingController.vb
@@ -337,5 +337,42 @@ Namespace DPC.Data.Controllers
             End Try
         End Function
 
+        ''' Gets total sales for a specific year
+        Public Shared Function GetSalesByYear(year As Integer) As Decimal
+            Try
+                Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
+                    conn.Open()
+                    Dim query As String = "SELECT COALESCE(SUM(CAST(REPLACE(REPLACE(totalAmount, '₱', ''), ',', '') AS DECIMAL(15,2))), 0) 
+                                   FROM walkinbilling 
+                                   WHERE YEAR(dateAdded) = @year"
+                    Using cmd As New MySqlCommand(query, conn)
+                        cmd.Parameters.AddWithValue("@year", year)
+                        Dim result = cmd.ExecuteScalar()
+                        Return If(result Is DBNull.Value OrElse result Is Nothing, 0D, Convert.ToDecimal(result))
+                    End Using
+                End Using
+            Catch ex As Exception
+                Debug.WriteLine("Error in GetSalesByYear: " & ex.Message)
+                Return 0D
+            End Try
+        End Function
+
+        ''' Gets the earliest year that has a billing record
+        Public Shared Function GetEarliestSalesYear() As Integer
+            Try
+                Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
+                    conn.Open()
+                    Dim query As String = "SELECT COALESCE(MIN(YEAR(dateAdded)), YEAR(NOW())) FROM walkinbilling"
+                    Using cmd As New MySqlCommand(query, conn)
+                        Dim result = cmd.ExecuteScalar()
+                        Return If(result Is DBNull.Value OrElse result Is Nothing, DateTime.Now.Year, Convert.ToInt32(result))
+                    End Using
+                End Using
+            Catch ex As Exception
+                Debug.WriteLine("Error in GetEarliestSalesYear: " & ex.Message)
+                Return DateTime.Now.Year
+            End Try
+        End Function
+
     End Class
 End Namespace


### PR DESCRIPTION
### **PROGRESS REPORT:**

Implemented a Year Picker feature that enables users to navigate annual sales data across different years. Users can switch between years using the arrow (< >) controls or by manually entering a specific year into the input field.