### PR TITLE
Manage Billing Statement and Manage Delivery Receipt

### DIFF
--- a/Components/UI/PopUpMenuSales.xaml
+++ b/Components/UI/PopUpMenuSales.xaml
@@ -200,7 +200,7 @@
                             </TextBlock>
                             <TextBlock Margin="10,3,0,3">
                                 <Hyperlink Click="NavigateToManageQuote">
-                                    <TextBlock Text="Manage Private Cost Estimate" Foreground="#d4d4d4" FontSize="13" FontFamily="Lexend"/>
+                                    <TextBlock Text="Manage Cost Estimate" Foreground="#d4d4d4" FontSize="13" FontFamily="Lexend"/>
                                 </Hyperlink>
                                 <TextBlock.ToolTip>
                                     <ToolTip Content="View and manage all cost estimates." Style="{StaticResource SpeechBubbleToolTip}" Placement="Top"/>

--- a/Views/Stocks/PurchaseOrder/Delivery/ManageDeliveryReceipt.xaml.vb
+++ b/Views/Stocks/PurchaseOrder/Delivery/ManageDeliveryReceipt.xaml.vb
@@ -21,9 +21,17 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
         Private _isInitialized As Boolean = False
         Private _currentDRNumber As String
 
+        ' User access control properties
+        Private _currentUserID As String
+        Private _currentUserRole As String
+        Private _isAdmin As Boolean = False
+
         Public Sub New()
             InitializeComponent()
             SetupDatePickers()
+
+            ' Initialize user access control
+            InitializeUserAccess()
 
             ' Initialize the search delay timer
             _typingTimer = New DispatcherTimer With {
@@ -34,6 +42,54 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
             ' Load data when the control is ready
             AddHandler Me.Loaded, AddressOf UserControl_Loaded
         End Sub
+
+        ''' <summary>
+        ''' Initialize user access control based on logged-in user
+        ''' </summary>
+        Private Sub InitializeUserAccess()
+            Try
+                ' Get current user ID from global cache
+                _currentUserID = CacheOnEmployeeID
+
+                ' Get user role from database
+                _currentUserRole = GetCurrentUserRole(_currentUserID)
+
+                ' Check if user is admin (has full access)
+                _isAdmin = (_currentUserRole = "Administrator" OrElse _currentUserRole = "Business Owner")
+
+                ' Display access level in UI (optional)
+                If Not _isAdmin Then
+                    Debug.WriteLine($"User {_currentUserID} has restricted access to delivery receipts")
+                End If
+            Catch ex As Exception
+                MessageBox.Show($"Error initializing user access: {ex.Message}", "Access Control Error", MessageBoxButton.OK, MessageBoxImage.Warning)
+                _isAdmin = False ' Default to restricted access on error
+            End Try
+        End Sub
+
+        ''' <summary>
+        ''' Get the role of the current user from the database
+        ''' </summary>
+        Private Function GetCurrentUserRole(employeeID As String) As String
+            Try
+                Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
+                    conn.Open()
+                    Dim query As String = "SELECT r.RoleName FROM employee e " &
+                                        "INNER JOIN userroles r ON e.UserRoleID = r.RoleID " &
+                                        "WHERE e.EmployeeID = @EmployeeID"
+                    Using cmd As New MySqlCommand(query, conn)
+                        cmd.Parameters.AddWithValue("@EmployeeID", employeeID)
+                        Dim result As Object = cmd.ExecuteScalar()
+                        If result IsNot DBNull.Value AndAlso result IsNot Nothing Then
+                            Return result.ToString()
+                        End If
+                    End Using
+                End Using
+            Catch ex As Exception
+                Debug.WriteLine($"Error getting user role: {ex.Message}")
+            End Try
+            Return "User" ' Default role
+        End Function
 
         Private Sub UserControl_Loaded(sender As Object, e As RoutedEventArgs)
             If Not _isInitialized Then
@@ -47,7 +103,7 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
         End Sub
 
         ''' <summary>
-        ''' Loads Delivery Receipt data into the DataGrid based on the selected limit
+        ''' Loads Delivery Receipt data into the DataGrid based on the selected limit and user access
         ''' </summary>
         Public Sub LoadData()
             Try
@@ -57,8 +113,8 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
                     limit = Convert.ToInt32(CType(cmbLimit.SelectedItem, ComboBoxItem).Content)
                 End If
 
-                ' Call the DeliveryReceiptController to fetch records
-                Dim receipts = DeliveryReceiptController.GetDeliveryReceipts(limit)
+                ' Call the DeliveryReceiptController to fetch records with user filtering
+                Dim receipts = DeliveryReceiptController.GetDeliveryReceipts(limit, _currentUserID, _isAdmin)
 
                 FormatDeliveryReceiptsForDisplay(receipts)
                 dataGrid.ItemsSource = receipts
@@ -119,11 +175,19 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
 
         ''' <summary>
         ''' Logic for the "Edit" button inside the DataGrid rows
+        ''' Only allows editing if user owns the record or is admin
         ''' </summary>
         Private Sub OpenEditDeliveryReceipt(sender As Object, e As RoutedEventArgs)
             Dim receipt As UniversalTransactionModel = TryCast(dataGrid.SelectedItem, UniversalTransactionModel)
 
             If receipt IsNot Nothing Then
+                ' Check access control
+                If Not _isAdmin AndAlso receipt.CreatedBy <> _currentUserID Then
+                    MessageBox.Show("You do not have permission to edit this delivery receipt.",
+                                  "Access Denied", MessageBoxButton.OK, MessageBoxImage.Warning)
+                    Return
+                End If
+
                 TransactionState.ResetRecord()
 
                 Dim fullReceiptData = DeliveryReceiptController.GetDeliveryReceiptByDRNumber(receipt.DocumentNumber)
@@ -141,6 +205,13 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
 
         Private Sub OpenContinueDeliveryReceipt(sender As Object, e As RoutedEventArgs)
             Dim receipt As UniversalTransactionModel = TryCast(dataGrid.SelectedItem, UniversalTransactionModel)
+
+            ' Check access control for continuing delivery
+            If Not _isAdmin AndAlso receipt.CreatedBy <> _currentUserID Then
+                MessageBox.Show("You do not have permission to continue this delivery receipt.",
+                              "Access Denied", MessageBoxButton.OK, MessageBoxImage.Warning)
+                Return
+            End If
 
             DeliveryDetails.ClearDeliveryDetails()
 
@@ -194,7 +265,7 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
 
                         If balance > 0 Then
                             Dim newItem = New Dictionary(Of String, String)(masterItem)
-                            newItem("Quantity") = balance.ToString() 
+                            newItem("Quantity") = balance.ToString()
                             newItem("MaxAllowed") = balance.ToString()
                             remainingList.Add(newItem)
                         End If
@@ -210,12 +281,20 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
 
         ''' <summary>
         ''' Logic for the "Delete" button inside the DataGrid rows
+        ''' Only allows deletion if user owns the record or is admin
         ''' </summary>
         Private Sub DeleteDeliveryReceipt(sender As Object, e As RoutedEventArgs)
-            Dim receipt As DeliveryReceiptModel = TryCast(dataGrid.SelectedItem, DeliveryReceiptModel)
+            Dim receipt As UniversalTransactionModel = TryCast(dataGrid.SelectedItem, UniversalTransactionModel)
             If receipt Is Nothing Then Return
 
-            Dim result = MessageBox.Show($"Are you sure you want to delete Delivery Receipt {receipt.DRNumber}?", "Confirm Delete", MessageBoxButton.YesNo, MessageBoxImage.Warning)
+            ' Check access control
+            If Not _isAdmin AndAlso receipt.CreatedBy <> _currentUserID Then
+                MessageBox.Show("You do not have permission to delete this delivery receipt.",
+                              "Access Denied", MessageBoxButton.OK, MessageBoxImage.Warning)
+                Return
+            End If
+
+            Dim result = MessageBox.Show($"Are you sure you want to delete Delivery Receipt {receipt.DocumentNumber}?", "Confirm Delete", MessageBoxButton.YesNo, MessageBoxImage.Warning)
 
             If result = MessageBoxResult.Yes Then
                 Try
@@ -223,7 +302,7 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
                     Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
                         conn.Open()
                         Using cmd As New MySqlCommand(query, conn)
-                            cmd.Parameters.AddWithValue("@drNumber", receipt.DRNumber)
+                            cmd.Parameters.AddWithValue("@drNumber", receipt.DocumentNumber)
                             cmd.ExecuteNonQuery()
                         End Using
                     End Using
@@ -254,8 +333,8 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
                     limit = Convert.ToInt32(CType(cmbLimit.SelectedItem, ComboBoxItem).Content)
                 End If
 
-                ' Optional: Add date filter parameters if your controller supports it
-                Dim results = DeliveryReceiptController.SearchDeliveryReceipts(SearchText.Text.Trim(), limit)
+                ' Use user-filtered search
+                Dim results = DeliveryReceiptController.SearchDeliveryReceipts(SearchText.Text.Trim(), limit, _currentUserID, _isAdmin)
                 FormatDeliveryReceiptsForDisplay(results)
                 dataGrid.ItemsSource = results
             Catch ex As Exception
@@ -286,12 +365,12 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
 
         Private Sub StartDatePicker_SelectedDateChanged(sender As Object, e As SelectionChangedEventArgs)
             startDateViewModel.SelectedDate = StartDatePicker.SelectedDate
-            PerformSearch() ' Re-run search on date change
+            If _isInitialized Then PerformSearch() ' Re-run search on date change
         End Sub
 
         Private Sub DueDatePicker_SelectedDateChanged(sender As Object, e As SelectionChangedEventArgs)
             dueDateViewModel.SelectedDate = DueDatePicker.SelectedDate
-            PerformSearch() ' Re-run search on date change
+            If _isInitialized Then PerformSearch() ' Re-run search on date change
         End Sub
 
         ' ==========================================
@@ -321,19 +400,19 @@ Namespace DPC.Views.Stocks.PurchaseOrder.Delivery
 
                         ' 5. Loop through the current items in the DataGrid and write them safely
                         For Each obj In dataGrid.Items
-                            Dim item As DeliveryReceiptModel = TryCast(obj, DeliveryReceiptModel)
+                            Dim item As UniversalTransactionModel = TryCast(obj, UniversalTransactionModel)
 
                             If item IsNot Nothing Then
                                 ' Using string interpolation safely handles Null/Empty data automatically
                                 ' We wrap everything in double quotes to prevent internal commas from breaking columns
-                                Dim drNum As String = $"{item.DRNumber}".Replace("""", """""")
-                                Dim invRef As String = $"{item.ReferenceInvoice}".Replace("""", """""")
-                                Dim drDate As String = $"{item.DRDate}".Replace("""", """""")
-                                Dim status As String = $"{item.DeliveryStatus}".Replace("""", """""")
+                                Dim drNum As String = $"{item.DocumentNumber}".Replace("""", """""")
+                                Dim invRef As String = $"{item.DocumentReference}".Replace("""", """""")
+                                Dim drDate As String = $"{item.DocumentDate}".Replace("""", """""")
+                                Dim status As String = If(item.IsFullyDelivered, "Complete", "Partial").Replace("""", """""")
                                 Dim client As String = $"{item.ClientName}".Replace("""", """""")
                                 Dim shipping As String = $"{item.ShippingMethod}".Replace("""", """""")
-                                Dim prepBy As String = $"{item.Username}".Replace("""", """""")
-                                Dim sysDate As String = $"{item.DateAddedDisplay}".Replace("""", """""")
+                                Dim prepBy As String = $"{item.PreparedBy}".Replace("""", """""")
+                                Dim sysDate As String = $"{item.DateAdded}".Replace("""", """""")
 
                                 writer.WriteLine($"""{drNum}"",""{invRef}"",""{drDate}"",""{status}"",""{client}"",""{shipping}"",""{prepBy}"",""{sysDate}""")
                             End If

--- a/data/Controllers/BIllingController.vb
+++ b/data/Controllers/BIllingController.vb
@@ -163,8 +163,9 @@ Namespace DPC.Data.Controllers
         ''' Inserts a new Billing Statement into the walkinbilling table
         Public Shared Function InsertBillingStatement(bm As BillingModel) As Boolean
             Try
-                Dim query As String = "INSERT INTO walkinbilling (billingNumber, billingDate, DRNo, clientID, companyRep, salesRep, preparedBy, approvedBy, paymentTerms, orderItems, warehouseID, base64img, taxProperty, discountProperty, deliveryFee, installationFee, totalTax, totalDiscount, totalAmount, billingNote, bankDetails, accName, accNo, remarks, dateAdded) " &
-                                     "VALUES (@billingNumber, @billingDate, @DRNo, @clientID, @companyRep, @salesRep, @preparedBy, @approvedBy, @paymentTerms, @orderItems, @warehouseID, @base64img, @taxProperty, @discountProperty, @deliveryFee, @installationFee, @totalTax, @totalDiscount, @totalAmount, @billingNote, @bankDetails, @accName, @accNo, @remarks, NOW())"
+                ' Updated query to include CreatedBy field
+                Dim query As String = "INSERT INTO walkinbilling (billingNumber, billingDate, DRNo, clientID, companyRep, salesRep, preparedBy, approvedBy, paymentTerms, orderItems, warehouseID, base64img, taxProperty, discountProperty, deliveryFee, installationFee, totalTax, totalDiscount, totalAmount, billingNote, bankDetails, accName, accNo, remarks, CreatedBy, dateAdded) " &
+                                     "VALUES (@billingNumber, @billingDate, @DRNo, @clientID, @companyRep, @salesRep, @preparedBy, @approvedBy, @paymentTerms, @orderItems, @warehouseID, @base64img, @taxProperty, @discountProperty, @deliveryFee, @installationFee, @totalTax, @totalDiscount, @totalAmount, @billingNote, @bankDetails, @accName, @accNo, @remarks, @CreatedBy, NOW())"
 
                 Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
                     conn.Open()
@@ -193,12 +194,18 @@ Namespace DPC.Data.Controllers
                         cmd.Parameters.AddWithValue("@accName", bm.AccName)
                         cmd.Parameters.AddWithValue("@accNo", bm.AccNo)
                         cmd.Parameters.AddWithValue("@remarks", bm.Remarks)
+                        ' Add the current user's ID as the creator
+                        cmd.Parameters.AddWithValue("@CreatedBy", CacheOnEmployeeID)
 
-                        Return cmd.ExecuteNonQuery() > 0
+                        Dim result As Boolean = cmd.ExecuteNonQuery() > 0
+
+                        If result Then
+                            MessageBox.Show($"Successfully Added the Billing Statement With Number {bm.BillingNumber}")
+                        End If
+
+                        Return result
                     End Using
                 End Using
-
-                MessageBox.Show($"Successfully Added the Billing Statement With Number {bm.BillingNumber}")
             Catch ex As Exception
                 MessageBox.Show("Failed to save billing statement: " & ex.Message)
                 Return False
@@ -208,6 +215,7 @@ Namespace DPC.Data.Controllers
         Public Shared Function UpdateBillingStatement(bm As BillingModel) As Boolean
             Try
                 ' SQL Query - Updates all fields where the billingNumber matches
+                ' NOTE: CreatedBy is NOT updated - it should remain the original creator
                 Dim query As String = "UPDATE walkinbilling SET " &
                              "billingDate = @billingDate, " &
                              "DRNo = @DRNo, " &
@@ -256,8 +264,8 @@ Namespace DPC.Data.Controllers
                                 cmd.Parameters.AddWithValue("@base64img", If(String.IsNullOrEmpty(bm.Base64img), "", bm.Base64img))
                                 cmd.Parameters.AddWithValue("@taxProperty", bm.TaxProperty)
                                 cmd.Parameters.AddWithValue("@discountProperty", bm.DiscountProperty)
-                                cmd.Parameters.AddWithValue("@DeliveryFee", bm.DeliveryFee)
-                                cmd.Parameters.AddWithValue("@InstallationFee", bm.InstallationFee)
+                                cmd.Parameters.AddWithValue("@deliveryFee", bm.DeliveryFee)
+                                cmd.Parameters.AddWithValue("@installationFee", bm.InstallationFee)
                                 cmd.Parameters.AddWithValue("@totalTax", bm.TotalTax)
                                 cmd.Parameters.AddWithValue("@totalDiscount", bm.TotalDiscount)
                                 cmd.Parameters.AddWithValue("@totalAmount", bm.TotalAmount)
@@ -266,18 +274,19 @@ Namespace DPC.Data.Controllers
                                 cmd.Parameters.AddWithValue("@accName", If(String.IsNullOrEmpty(bm.AccName), "", bm.AccName))
                                 cmd.Parameters.AddWithValue("@accNo", If(String.IsNullOrEmpty(bm.AccNo), "", bm.AccNo))
                                 cmd.Parameters.AddWithValue("@remarks", If(String.IsNullOrEmpty(bm.Remarks), "", bm.Remarks))
+                                ' NOTE: CreatedBy is intentionally NOT included - it should never change
 
                                 Dim rowsAffected As Integer = cmd.ExecuteNonQuery()
 
                                 If rowsAffected > 0 Then
                                     transaction.Commit()
+                                    MessageBox.Show($"Successfully Updated the Billing Statement With Number {bm.BillingNumber}")
                                     Return True
                                 Else
                                     transaction.Rollback()
                                     Return False
                                 End If
                             End Using
-                            MessageBox.Show($"Successfully Updated the Billing Statement With Number {bm.BillingNumber}")
                         Catch ex As Exception
                             transaction.Rollback()
                             Throw ex

--- a/data/Controllers/DeliveryReceiptController.vb
+++ b/data/Controllers/DeliveryReceiptController.vb
@@ -28,8 +28,9 @@ Namespace DPC.Data.Controllers
             Try
                 Dim checkDuplicateQuery As String = "SELECT COUNT(*) FROM deliveryreceipts WHERE DRNumber = @DRNumber"
 
-                Dim addQuery As String = "INSERT INTO deliveryreceipts (DRNumber, ReferenceInvoice, DRDate, ClientName, ClientDetails, DeliveryNotes, ShippingMethod, DeliveryStatus, ApprovedBy, PaymentTerm, OrderItems, Username, DateAdded) " &
-                                         "VALUES (@DRNumber, @ReferenceInvoice, @DRDate, @ClientName, @ClientDetails, @DeliveryNotes, @ShippingMethod, @DeliveryStatus, @ApprovedBy, @PaymentTerm, @OrderItems, @Username, NOW())"
+                ' UPDATED: Added CreatedBy field
+                Dim addQuery As String = "INSERT INTO deliveryreceipts (DRNumber, ReferenceInvoice, DRDate, ClientName, ClientDetails, DeliveryNotes, ShippingMethod, DeliveryStatus, ApprovedBy, PaymentTerm, OrderItems, Username, CreatedBy, DateAdded) " &
+                                         "VALUES (@DRNumber, @ReferenceInvoice, @DRDate, @ClientName, @ClientDetails, @DeliveryNotes, @ShippingMethod, @DeliveryStatus, @ApprovedBy, @PaymentTerm, @OrderItems, @Username, @CreatedBy, NOW())"
 
                 Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
                     conn.Open()
@@ -60,6 +61,8 @@ Namespace DPC.Data.Controllers
                                 addCmd.Parameters.AddWithValue("@PaymentTerm", PaymentTerm)
                                 addCmd.Parameters.AddWithValue("@OrderItems", OrderItems)
                                 addCmd.Parameters.AddWithValue("@Username", Username)
+                                ' ADDED: Set the current user as the creator
+                                addCmd.Parameters.AddWithValue("@CreatedBy", CacheOnEmployeeID)
 
                                 addCmd.ExecuteNonQuery()
                                 transaction.Commit()
@@ -89,119 +92,181 @@ Namespace DPC.Data.Controllers
             End Try
         End Function
 
-        Public Shared Function GetDeliveryReceipts(limit As Integer) As ObservableCollection(Of UniversalTransactionModel)
+        ''' <summary>
+        ''' Gets delivery receipts with user-based filtering
+        ''' </summary>
+        Public Shared Function GetDeliveryReceipts(limit As Integer, currentUserID As String, isAdmin As Boolean) As ObservableCollection(Of UniversalTransactionModel)
             Dim receipts As New ObservableCollection(Of UniversalTransactionModel)
+
             Try
                 Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
                     conn.Open()
-                    Dim query As String = "
-                SELECT 
-                    DRNumber, ReferenceInvoice, DRDate, ClientName, 
-                    ClientDetails, DeliveryNotes, ShippingMethod, 
-                    DeliveryStatus, ApprovedBy, PaymentTerm, 
-                    OrderItems, Username, DateAdded 
-                FROM deliveryreceipts 
-                ORDER BY DateAdded DESC 
-                LIMIT @limit"
+
+                    Dim query As String
+                    If isAdmin Then
+                        ' Admin sees all records
+                        query = "SELECT * FROM deliveryreceipts ORDER BY dateAdded DESC LIMIT @Limit"
+                    Else
+                        ' Regular users see only their own records
+                        query = "SELECT * FROM deliveryreceipts WHERE CreatedBy = @CreatedBy ORDER BY dateAdded DESC LIMIT @Limit"
+                    End If
 
                     Using cmd As New MySqlCommand(query, conn)
-                        cmd.Parameters.AddWithValue("@limit", limit)
+                        cmd.Parameters.AddWithValue("@Limit", limit)
+                        If Not isAdmin Then
+                            cmd.Parameters.AddWithValue("@CreatedBy", currentUserID)
+                        End If
 
                         Using reader As MySqlDataReader = cmd.ExecuteReader()
                             While reader.Read()
-                                Dim jsonString As String = If(reader("OrderItems") Is DBNull.Value, "[]", reader("OrderItems").ToString())
-                                Dim itemsCollection As ObservableCollection(Of OrderItems)
-                                Try
-                                    Dim deserializedList = JsonConvert.DeserializeObject(Of List(Of OrderItems))(jsonString)
-                                    itemsCollection = New ObservableCollection(Of OrderItems)(deserializedList)
-                                Catch
-                                    itemsCollection = New ObservableCollection(Of OrderItems)()
-                                End Try
-
-                                receipts.Add(New UniversalTransactionModel() With {
-                            .DocumentNumber = reader("DRNumber").ToString(),
-                            .DocumentReference = reader("ReferenceInvoice").ToString(),
-                            .DocumentDate = If(reader("DRDate") Is DBNull.Value, "-", reader("DRDate").ToString()),
-                            .ClientName = reader("ClientName").ToString(),
-                            .ClientDetails = If(reader("ClientDetails") Is DBNull.Value, String.Empty, reader("ClientDetails").ToString()),
-                            .Notes = If(reader("DeliveryNotes") Is DBNull.Value, String.Empty, reader("DeliveryNotes").ToString()),
-                            .ShippingMethod = reader("ShippingMethod").ToString(),
-                            .Status = reader("DeliveryStatus").ToString(),
-                            .ApprovedBy = If(reader("ApprovedBy") Is DBNull.Value, "-", reader("ApprovedBy").ToString()),
-                            .PaymentTerm = If(reader("PaymentTerm") Is DBNull.Value, "-", reader("PaymentTerm").ToString()),
-                            .OrderItems = itemsCollection,
-                            .RawItemsJson = jsonString,
-                            .SalesRep = reader("Username").ToString(),
-                            .DateAdded = If(reader("DateAdded") Is DBNull.Value, DateTime.MinValue, Convert.ToDateTime(reader("DateAdded")).ToString("MMM dd, yyyy"))
-                        })
+                                receipts.Add(MapReaderToUniversalModel(reader))
                             End While
                         End Using
                     End Using
                 End Using
-
             Catch ex As Exception
-                Debug.WriteLine("Error in GetDeliveryReceipts: " & ex.Message)
+                MessageBox.Show($"Error loading delivery receipts: {ex.Message}", "Database Error", MessageBoxButton.OK, MessageBoxImage.Error)
             End Try
 
             Return receipts
         End Function
 
+        ''' <summary>
+        ''' Search delivery receipts with user-based filtering
+        ''' </summary>
+        Public Shared Function SearchDeliveryReceipts(searchTerm As String, limit As Integer, currentUserID As String, isAdmin As Boolean) As ObservableCollection(Of UniversalTransactionModel)
+            Dim results As New ObservableCollection(Of UniversalTransactionModel)
+
+            Try
+                Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
+                    conn.Open()
+
+                    Dim query As String
+                    If isAdmin Then
+                        ' Admin searches all records
+                        query = "SELECT * FROM deliveryreceipts WHERE " &
+                       "(DRNumber LIKE @SearchTerm OR ReferenceInvoice LIKE @SearchTerm OR ClientName LIKE @SearchTerm) " &
+                       "ORDER BY dateAdded DESC LIMIT @Limit"
+                    Else
+                        ' Regular users search only their own records
+                        query = "SELECT * FROM deliveryreceipts WHERE CreatedBy = @CreatedBy AND " &
+                       "(DRNumber LIKE @SearchTerm OR ReferenceInvoice LIKE @SearchTerm OR ClientName LIKE @SearchTerm) " &
+                       "ORDER BY dateAdded DESC LIMIT @Limit"
+                    End If
+
+                    Using cmd As New MySqlCommand(query, conn)
+                        cmd.Parameters.AddWithValue("@SearchTerm", "%" & searchTerm & "%")
+                        cmd.Parameters.AddWithValue("@Limit", limit)
+                        If Not isAdmin Then
+                            cmd.Parameters.AddWithValue("@CreatedBy", currentUserID)
+                        End If
+
+                        Using reader As MySqlDataReader = cmd.ExecuteReader()
+                            While reader.Read()
+                                results.Add(MapReaderToUniversalModel(reader))
+                            End While
+                        End Using
+                    End Using
+                End Using
+            Catch ex As Exception
+                MessageBox.Show($"Error searching delivery receipts: {ex.Message}", "Database Error", MessageBoxButton.OK, MessageBoxImage.Error)
+            End Try
+
+            Return results
+        End Function
+
+        Private Shared Function MapReaderToUniversalModel(reader As MySqlDataReader) As UniversalTransactionModel
+            Return New UniversalTransactionModel With {
+        .DocumentNumber = If(reader("DRNumber") IsNot DBNull.Value, reader("DRNumber").ToString(), ""),
+        .DocumentReference = If(reader("ReferenceInvoice") IsNot DBNull.Value, reader("ReferenceInvoice").ToString(), ""),
+        .DocumentDate = If(reader("DRDate") IsNot DBNull.Value, reader("DRDate").ToString(), "-"),
+        .ClientName = If(reader("ClientName") IsNot DBNull.Value, reader("ClientName").ToString(), ""),
+        .ClientDetails = If(reader("ClientDetails") IsNot DBNull.Value, reader("ClientDetails").ToString(), ""),
+        .ShippingMethod = If(reader("ShippingMethod") IsNot DBNull.Value, reader("ShippingMethod").ToString(), ""),
+        .PreparedBy = If(reader("Username") IsNot DBNull.Value, reader("Username").ToString(), ""),
+        .ApprovedBy = If(reader("ApprovedBy") IsNot DBNull.Value, reader("ApprovedBy").ToString(), ""),
+        .PaymentTerm = If(reader("PaymentTerm") IsNot DBNull.Value, reader("PaymentTerm").ToString(), ""),
+        .Notes = If(reader("DeliveryNotes") IsNot DBNull.Value, reader("DeliveryNotes").ToString(), ""),
+        .RawItemsJson = If(reader("OrderItems") IsNot DBNull.Value, reader("OrderItems").ToString(), "[]"),
+        .DateAdded = If(reader("dateAdded") IsNot DBNull.Value, reader.GetDateTime("dateAdded").ToString("MMM d, yyyy"), ""),
+        .CreatedBy = If(reader("CreatedBy") IsNot DBNull.Value, reader("CreatedBy").ToString(), "")
+    }
+        End Function
+
+        ''' <summary>
+        ''' Gets a single delivery receipt by DR Number for editing
+        ''' </summary>
         Public Shared Function GetDeliveryReceiptByDRNumber(drNumber As String) As UniversalTransactionModel
             Try
                 Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
                     conn.Open()
-                    Dim query As String = "SELECT * FROM deliveryreceipts WHERE drNumber = @dr"
+
+                    Dim query As String = "SELECT * FROM deliveryreceipts WHERE DRNumber = @DRNumber LIMIT 1"
 
                     Using cmd As New MySqlCommand(query, conn)
-                        cmd.Parameters.AddWithValue("@dr", drNumber)
-                        Using reader = cmd.ExecuteReader()
+                        cmd.Parameters.AddWithValue("@DRNumber", drNumber)
+
+                        Using reader As MySqlDataReader = cmd.ExecuteReader()
                             If reader.Read() Then
-                                Return MapReaderToDeliveryModel(reader)
+                                Dim receipt = MapReaderToUniversalModel(reader)
+
+                                ' Parse the OrderItems JSON into the ObservableCollection
+                                If Not String.IsNullOrEmpty(receipt.RawItemsJson) Then
+                                    Try
+                                        Dim itemsList = JsonConvert.DeserializeObject(Of List(Of Dictionary(Of String, String)))(receipt.RawItemsJson)
+
+                                        If itemsList IsNot Nothing Then
+                                            receipt.OrderItems.Clear()
+
+                                            For Each dict In itemsList
+                                                Dim newItem As New OrderItems()
+
+                                                newItem.ProductName = If(dict.ContainsKey("ProductName"), dict("ProductName"), "")
+                                                newItem.Quantity = If(dict.ContainsKey("Quantity"), dict("Quantity"), "0")
+                                                newItem.Description = If(dict.ContainsKey("Description"), dict("Description"), "")
+                                                newItem.ProductDescription = If(dict.ContainsKey("ProductDescription"), dict("ProductDescription"), "")
+                                                newItem.UnitPrice = If(dict.ContainsKey("UnitPrice"), dict("UnitPrice"),
+                                                                    If(dict.ContainsKey("Rate"), dict("Rate"), "0.00"))
+                                                newItem.LinePrice = If(dict.ContainsKey("LinePrice"), dict("LinePrice"),
+                                                                    If(dict.ContainsKey("Amount"), dict("Amount"), "0.00"))
+
+                                                Dim isHeaderVal As Boolean = False
+                                                If dict.ContainsKey("IsHeaderRow") Then
+                                                    Boolean.TryParse(dict("IsHeaderRow").ToString(), isHeaderVal)
+                                                End If
+                                                newItem.IsHeaderRow = isHeaderVal
+                                                newItem.IsCategoryHeader = isHeaderVal
+
+                                                Dim isSubtotalVal As Boolean = False
+                                                If dict.ContainsKey("IsSubtotalRow") Then
+                                                    Boolean.TryParse(dict("IsSubtotalRow").ToString(), isSubtotalVal)
+                                                ElseIf dict.ContainsKey("IsSubotalRow") Then
+                                                    Boolean.TryParse(dict("IsSubotalRow").ToString(), isSubtotalVal)
+                                                End If
+                                                newItem.IsSubtotalRow = isSubtotalVal
+
+                                                newItem.ProductDescriptionVisibility = If(String.IsNullOrWhiteSpace(newItem.ProductDescription),
+                                                             Visibility.Collapsed, Visibility.Visible)
+
+                                                receipt.OrderItems.Add(newItem)
+                                            Next
+                                        End If
+                                    Catch jsonEx As Exception
+                                        Debug.WriteLine($"Error parsing delivery items JSON: {jsonEx.Message}")
+                                    End Try
+                                End If
+
+                                Return receipt
                             End If
                         End Using
                     End Using
                 End Using
             Catch ex As Exception
-                Debug.WriteLine("Error fetching full DR: " & ex.Message)
+                Debug.WriteLine($"Error in GetDeliveryReceiptByDRNumber: {ex.Message}")
+                MessageBox.Show($"Error retrieving delivery receipt: {ex.Message}", "Database Error", MessageBoxButton.OK, MessageBoxImage.Error)
             End Try
+
             Return Nothing
-        End Function
-
-        Private Shared Function MapReaderToDeliveryModel(reader As MySqlDataReader) As UniversalTransactionModel
-            ' 1. Capture the JSON string safely
-            Dim jsonItems As String = If(reader("orderItems") Is DBNull.Value, "[]", reader("orderItems").ToString())
-
-            ' 2. Convert JSON string to ObservableCollection
-            Dim itemsCollection As New ObservableCollection(Of OrderItems)()
-            Try
-                If Not String.IsNullOrWhiteSpace(jsonItems) Then
-                    Dim list = JsonConvert.DeserializeObject(Of List(Of OrderItems))(jsonItems)
-                    itemsCollection = New ObservableCollection(Of OrderItems)(list)
-                End If
-            Catch ex As Exception
-                Debug.WriteLine("Error parsing OrderItems JSON: " & ex.Message)
-            End Try
-
-            ' 3. Return the populated Model
-            Return New UniversalTransactionModel With {
-        .DocumentNumber = reader("drNumber").ToString(),
-        .DocumentReference = reader("ReferenceInvoice").ToString(),
-        .ClientName = reader("clientName").ToString(),
-        .ClientDetails = reader("clientDetails").ToString(),
-        .DocumentDate = If(reader("drDate") Is DBNull.Value, "", Convert.ToDateTime(reader("drDate")).ToString("MMM dd, yyyy")),
-        .ShippingMethod = reader("shippingMethod").ToString(),
-        .Notes = reader("deliveryNotes").ToString(),
-        .ApprovedBy = reader("approvedBy").ToString(),
-        .PaymentTerm = reader("paymentTerm").ToString(),
-        .OrderItems = itemsCollection,
-        .RawItemsJson = jsonItems,
-        .Status = reader("deliveryStatus").ToString(),
-        .DateAdded = If(reader("DateAdded") Is DBNull.Value, DateTime.MinValue, Convert.ToDateTime(reader("DateAdded")).ToString("MMM dd, yyyy"))
-    }
-        End Function
-
-        Public Shared Function SearchDeliveryReceipts()
-            Return New ObservableCollection(Of UniversalTransactionModel)()
         End Function
 
         Public Shared Function GetAccumulatedDeliveryTotals(invoiceNo As String) As Dictionary(Of String, Integer)

--- a/data/models/UniversalTransactionModel.vb
+++ b/data/models/UniversalTransactionModel.vb
@@ -28,6 +28,7 @@ Namespace DPC.Data.Models
         Public Property SalesRep As String = ""
         Public Property PreparedBy As String = ""
         Public Property ApprovedBy As String = ""
+        Public Property CreatedBy As String = ""
 
         ' --- 4. WAREHOUSE & LOGISTICS ---
         Public Property WarehouseName As String = ""


### PR DESCRIPTION
Changes: 

1. Fix the bug where sales account cannot see their created files in manage billing statement but it shows in different module like in Manage Delivery Receipt.
2. Replace “Manage Private Cost Estimate” to “Manage Cost Estimate.”
3. Manage Delivery Receipt module has now user account only access files/ view just like in Manage Billing Statement.

Database Configuration:


<img width="964" height="226" alt="Dbase config for manage delivery receipts" src="https://github.com/user-attachments/assets/e6419eb9-44cc-4d14-ab86-4ad09efb27e4" />
<img width="964" height="226" alt="Dbase config for manage delivery receipts" src="https://github.com/user-attachments/assets/e6419eb9-44cc-4d14-ab86-4ad09efb27e4" />

 
