### PR TITLE
Billing Statement Preview Print Fix

### DIFF
--- a/Components/Forms/UniversalEditablePreviewDocument.xaml.vb
+++ b/Components/Forms/UniversalEditablePreviewDocument.xaml.vb
@@ -83,10 +83,10 @@ Namespace DPC.Components.Forms
             DocumentNumber.Text = data.DocumentNumber
             DocumentDate.Text = data.DocumentDate
             DocumentValidityDate.Text = data.DocumentValidity
-            Subtotal.Text = data.Subtotal
-            lblVatValue.Text = data.VatValue
+            Subtotal.Text = FormatMoneyForDisplay(data.Subtotal)
+            lblVatValue.Text = FormatMoneyForDisplay(data.VatValue)
             lblVat.Text = data.VatLabel
-            TotalCost.Text = data.TotalCost
+            TotalCost.Text = FormatMoneyForDisplay(data.TotalCost)
 
 
             noteBox.Text = data.Notes
@@ -97,8 +97,8 @@ Namespace DPC.Components.Forms
             lblTermsDisplay.Text = data.PaymentTerms
             lblSubtotal.Text = data.SubtotalLabel
             lblFeeType.Text = data.DeliveryMobilizationLabel
-            Delivery.Text = data.FeeValue
-            Installation.Text = data.InstallationFee
+            Delivery.Text = FormatMoneyForDisplay(data.FeeValue)
+            Installation.Text = FormatMoneyForDisplay(data.InstallationFee)
 
             If data.DocumentTitle.StartsWith("BILLING") Then
                 CNIdentifier.Text = "BS No: "
@@ -583,6 +583,19 @@ Namespace DPC.Components.Forms
         '    data.PaymentTerms = cmbTerms.Text
         'End Sub
 #End Region
+
+        Private Function FormatMoneyForDisplay(value As String) As String
+            If String.IsNullOrWhiteSpace(value) Then Return "₱ 0.00"
+
+            Dim clean = value.Replace("₱", "").Replace(",", "").Trim()
+            Dim dec As Decimal
+
+            If Decimal.TryParse(clean, NumberStyles.Any, CultureInfo.InvariantCulture, dec) Then
+                Return "₱ " & dec.ToString("N2")  ' N2 adds commas
+            End If
+
+            Return value
+        End Function
 
     End Class
 End Namespace

--- a/Views/Stocks/PurchaseOrder/WalkIn/WalkInNewOrder.xaml.vb
+++ b/Views/Stocks/PurchaseOrder/WalkIn/WalkInNewOrder.xaml.vb
@@ -123,6 +123,11 @@ Namespace DPC.Views.Stocks.PurchaseOrder.WalkIn
             _typingTimer.Start()
         End Sub
 
+        Private Function CleanMoneyText(value As String) As String
+            If String.IsNullOrWhiteSpace(value) Then Return "0.00"
+            Return value.Replace("₱", "").Replace(",", "").Trim()
+        End Function
+
         Private Sub txtQuoteNumber_TextChanged(sender As Object, e As TextChangedEventArgs)
             If Not _isInitialized Then Return
 
@@ -483,8 +488,8 @@ Namespace DPC.Views.Stocks.PurchaseOrder.WalkIn
 
             _isInitialized = True
 
-            txtDeliveryFee_TextChange(txtDeliveryFee, Nothing)
-            txtInstallationFee_TextChanged(txtInstallationFee, Nothing)
+            txtDeliveryFee.Text = CleanMoneyText(model.FeeValue)
+            txtInstallationFee.Text = CleanMoneyText(model.InstallationFee)
 
             UpdateGrandTotal()
         End Sub
@@ -1835,7 +1840,7 @@ Select(Function(txt) txt.Name).Distinct()
                     data.SubtotalLabel = "SUBTOTAL VAT EX."
                 Else
                     data.VatLabel = "VAT 12%"
-                    data.SubtotalLabel = "SUBTOTAL VAT IN."
+                    data.SubtotalLabel = "SUBTOTAL VAT INC."
                 End If
 
                 data.VatType = selectedTaxType


### PR DESCRIPTION
Changes:

1. Added a comma for the subtotal vat inc.
2. “SUBTOTAL VAT IN.” Changed to “SUBTOTAL VAT INC.”
3. Fix Grand Total. It can now reflect the true values of total cost.
