### PR TITLE
Project List Routing & Global Status Card Aggregation

### DIFF
--- a/Views/Project/AddProject1.xaml
+++ b/Views/Project/AddProject1.xaml
@@ -450,10 +450,50 @@
                         <ComboBoxItem Content="JOANNA"/>
                     </ComboBox>
                 </Border>
+                <!-- ── Add to List ── -->
+                <TextBlock Text="Add to List:" Margin="0,20,0,10" FontWeight="SemiBold" Foreground="#474747"/>
+                <Border Style="{StaticResource RoundedBorderStyle}" Background="White" Padding="15,10">
+                    <StackPanel Orientation="Horizontal">
+                        <RadioButton x:Name="radListDPCGovSales"
+                                     Content="DPC Gov Sales"
+                                     GroupName="ProjectList"
+                                     IsChecked="True"
+                                     Margin="0,0,40,0"
+                                     VerticalAlignment="Center"
+                                     Foreground="#474747"
+                                     FontSize="14"/>
+                        <RadioButton x:Name="radListAwarded"
+                                     Content="Awarded Projects"
+                                     GroupName="ProjectList"
+                                     Margin="0,0,40,0"
+                                     VerticalAlignment="Center"
+                                     Foreground="#474747"
+                                     FontSize="14"/>
+                        <RadioButton x:Name="radListCollection"
+                                     Content="Collection"
+                                     GroupName="ProjectList"
+                                     VerticalAlignment="Center"
+                                     Foreground="#474747"
+                                     FontSize="14"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- ── Project Awarded Status (keep as-is) ── -->
                 <TextBlock Text="Project Awarded Status:" Margin="0,20,0,10" FontWeight="SemiBold" Foreground="#474747"/>
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
-                    <RadioButton x:Name="radAwardedYes" Content="Yes (Awarded)" Margin="0,0,30,0" VerticalAlignment="Center" Foreground="#474747" FontSize="14"/>
-                    <RadioButton x:Name="radAwardedNo" Content="No (Not Awarded)" VerticalAlignment="Center" Foreground="#474747" FontSize="14"/>
+                    <RadioButton x:Name="radAwardedYes"
+                                 Content="Yes (Awarded)"
+                                 GroupName="AwardedStatus"
+                                 Margin="0,0,30,0"
+                                 VerticalAlignment="Center"
+                                 Foreground="#474747"
+                                 FontSize="14"/>
+                    <RadioButton x:Name="radAwardedNo"
+                                 Content="No (Not Awarded)"
+                                 GroupName="AwardedStatus"
+                                 VerticalAlignment="Center"
+                                 Foreground="#474747"
+                                 FontSize="14"/>
                 </StackPanel>
 
                 <!-- ══════════════════════════════════════

--- a/Views/Project/AddProject1.xaml.vb
+++ b/Views/Project/AddProject1.xaml.vb
@@ -302,6 +302,21 @@ Namespace DPC.Views.Project
         End Sub
 
         ' =========================================================
+        ' PROJECT LIST HELPER
+        ' Reads the radListAwarded / radListCollection / default
+        ' radio buttons and returns the matching DB list key.
+        ' =========================================================
+        Private Function GetSelectedProjectList() As String
+            If radListAwarded.IsChecked = True Then
+                Return "AWARDED_PROJECTS"
+            ElseIf radListCollection.IsChecked = True Then
+                Return "COLLECTION"
+            Else
+                Return "DPC_GOV_SALES"   ' default when neither is checked
+            End If
+        End Function
+
+        ' =========================================================
         ' SAVE / SUBMIT
         ' =========================================================
         Private Sub Button_Click_1(sender As Object, e As RoutedEventArgs)
@@ -318,6 +333,9 @@ Namespace DPC.Views.Project
             Dim selectedStatus As String = GetComboText(cmbStatus)
             Dim selectedRemarks As String = GetComboText(cmbRemarks)
             Dim selectedAssignSales As String = GetComboText(cmbAssignSales)
+
+            ' ── NEW: resolve which project list was selected ──
+            Dim projectList As String = GetSelectedProjectList()
 
             Dim noteText As String = New TextRange(EditorBox.Document.ContentStart, EditorBox.Document.ContentEnd).Text.Trim()
 
@@ -346,6 +364,7 @@ Namespace DPC.Views.Project
                 .Status = selectedStatus,
                 .Remarks = selectedRemarks,
                 .AssignSales = selectedAssignSales,
+                .ProjectList = projectList,           ' ── NEW ──
                 .Note = noteText,
                 .IsAwarded = radAwardedYes.IsChecked.GetValueOrDefault(False)
             }
@@ -391,6 +410,10 @@ Namespace DPC.Views.Project
             cmbRemarks.SelectedIndex = -1
             cmbAssignSales.SelectedIndex = -1
             EditorBox.Document.Blocks.Clear()
+
+            ' Reset project list radio buttons
+            radListAwarded.IsChecked = False
+            radListCollection.IsChecked = False
 
             ' ViewModels
             dateViewModel.SelectedDate = Nothing

--- a/Views/Project/EditProject.xaml
+++ b/Views/Project/EditProject.xaml
@@ -451,10 +451,50 @@
                         <ComboBoxItem Content="JOANNA"/>
                     </ComboBox>
                 </Border>
+                <!-- ── Add to List ── -->
+                <TextBlock Text="Add to List:" Margin="0,20,0,10" FontWeight="SemiBold" Foreground="#474747"/>
+                <Border Style="{StaticResource RoundedBorderStyle}" Background="White" Padding="15,10">
+                    <StackPanel Orientation="Horizontal">
+                        <RadioButton x:Name="radListDPCGovSales"
+                     Content="DPC Gov Sales"
+                     GroupName="ProjectList"
+                     IsChecked="True"
+                     Margin="0,0,40,0"
+                     VerticalAlignment="Center"
+                     Foreground="#474747"
+                     FontSize="14"/>
+                        <RadioButton x:Name="radListAwarded"
+                     Content="Awarded Projects"
+                     GroupName="ProjectList"
+                     Margin="0,0,40,0"
+                     VerticalAlignment="Center"
+                     Foreground="#474747"
+                     FontSize="14"/>
+                        <RadioButton x:Name="radListCollection"
+                     Content="Collection"
+                     GroupName="ProjectList"
+                     VerticalAlignment="Center"
+                     Foreground="#474747"
+                     FontSize="14"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- ── Project Awarded Status (keep as-is) ── -->
                 <TextBlock Text="Project Awarded Status:" Margin="0,20,0,10" FontWeight="SemiBold" Foreground="#474747"/>
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
-                    <RadioButton x:Name="radAwardedYes" Content="Yes (Awarded)" Margin="0,0,30,0" VerticalAlignment="Center" Foreground="#474747" FontSize="14"/>
-                    <RadioButton x:Name="radAwardedNo" Content="No (Not Awarded)" VerticalAlignment="Center" Foreground="#474747" FontSize="14"/>
+                    <RadioButton x:Name="radAwardedYes"
+                 Content="Yes (Awarded)"
+                 GroupName="AwardedStatus"
+                 Margin="0,0,30,0"
+                 VerticalAlignment="Center"
+                 Foreground="#474747"
+                 FontSize="14"/>
+                    <RadioButton x:Name="radAwardedNo"
+                 Content="No (Not Awarded)"
+                 GroupName="AwardedStatus"
+                 VerticalAlignment="Center"
+                 Foreground="#474747"
+                 FontSize="14"/>
                 </StackPanel>
 
                 <!-- ══════════════════════════════════════

--- a/Views/Project/EditProject.xaml.vb
+++ b/Views/Project/EditProject.xaml.vb
@@ -61,6 +61,17 @@ Namespace DPC.Views.Project
                 SelectComboByContent(cmbRemarks, p.Remarks)
                 SelectComboByContent(cmbAssignSales, p.AssignSales)
 
+                ' ── Restore ProjectList radio button ──
+                Select Case p.ProjectList
+                    Case "AWARDED_PROJECTS"
+                        radListAwarded.IsChecked = True
+                    Case "COLLECTION"
+                        radListCollection.IsChecked = True
+                    Case Else
+                        ' DPC_GOV_SALES is the default — leave both unchecked
+                        ' (or add a radListDPCGov radio and check it here)
+                End Select
+
                 If p.IsAwarded Then
                     radAwardedYes.IsChecked = True
                 Else
@@ -87,6 +98,24 @@ Namespace DPC.Views.Project
             Next
         End Sub
 
+        ' =========================================================
+        ' PROJECT LIST HELPER
+        ' Reads the radListAwarded / radListCollection / default
+        ' radio buttons and returns the matching DB list key.
+        ' =========================================================
+        Private Function GetSelectedProjectList() As String
+            If radListAwarded.IsChecked = True Then
+                Return "AWARDED_PROJECTS"
+            ElseIf radListCollection.IsChecked = True Then
+                Return "COLLECTION"
+            Else
+                Return "DPC_GOV_SALES"   ' default when neither is checked
+            End If
+        End Function
+
+        ' =========================================================
+        ' TO-UPPER HANDLER
+        ' =========================================================
         Private Sub TxtToUpper_TextChanged(sender As Object, e As TextChangedEventArgs)
             Dim tb = TryCast(sender, TextBox)
             If tb Is Nothing Then Return
@@ -100,12 +129,18 @@ Namespace DPC.Views.Project
             End If
         End Sub
 
+        ' =========================================================
+        ' NUMBER ONLY
+        ' =========================================================
         Private Sub txtZipCode_PreviewTextInput(sender As Object, e As TextCompositionEventArgs)
             If Not Char.IsDigit(e.Text, e.Text.Length - 1) Then
                 e.Handled = True
             End If
         End Sub
 
+        ' =========================================================
+        ' BUDGET / NUMERIC FORMATTER
+        ' =========================================================
         Private Sub txtBudget_TextChanged(sender As Object, e As TextChangedEventArgs)
             Dim tb = TryCast(sender, TextBox)
             If tb Is Nothing Then Return
@@ -128,6 +163,9 @@ Namespace DPC.Views.Project
             AddHandler tb.TextChanged, AddressOf txtBudget_TextChanged
         End Sub
 
+        ' =========================================================
+        ' DATE PICKER CLICK HANDLERS
+        ' =========================================================
         Private Sub DateButton_Click(sender As Object, e As RoutedEventArgs)
             DatePicker.DisplayDateStart = DateTime.Today
             DatePicker.IsDropDownOpen = True
@@ -148,6 +186,9 @@ Namespace DPC.Views.Project
             ReceiveDatePicker.IsDropDownOpen = True
         End Sub
 
+        ' =========================================================
+        ' DATE PICKER SELECTION CHANGED HANDLERS
+        ' =========================================================
         Private Sub DatePicker_SelectedDateChanged(sender As Object, e As SelectionChangedEventArgs)
             SyncDateViewModel(sender, dateViewModel, DateButton)
         End Sub
@@ -172,6 +213,9 @@ Namespace DPC.Views.Project
             If be IsNot Nothing Then be.UpdateTarget()
         End Sub
 
+        ' =========================================================
+        ' SAVE / UPDATE
+        ' =========================================================
         Private Sub Button_Click_1(sender As Object, e As RoutedEventArgs)
             If String.IsNullOrWhiteSpace(txtProjectTitle.Text) Then
                 MessageBox.Show("Project Title is required.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning)
@@ -189,6 +233,10 @@ Namespace DPC.Views.Project
                     Dim selectedMode As String = GetComboText(cmbModeOfSubmission)
                     Dim selectedRemarks As String = GetComboText(cmbRemarks)
                     Dim selectedAssignSales As String = GetComboText(cmbAssignSales)
+
+                    ' ── NEW: resolve which project list was selected ──
+                    Dim projectList As String = GetSelectedProjectList()
+
                     Dim noteText As String = New TextRange(EditorBox.Document.ContentStart, EditorBox.Document.ContentEnd).Text.Trim()
                     Dim rawABC As Long
                     Long.TryParse(txtABC.Text.Replace(",", ""), rawABC)
@@ -201,6 +249,7 @@ Namespace DPC.Views.Project
                         "EmailAddress=@email, AreaOfDelivery=@area, PreBidDate=@prebid, " &
                         "ClosingDate=@closing, ABC=@abc, BidRFQOffer=@bid, ReceiveDate=@receive, " &
                         "ModeOfSubmission=@mode, Remarks=@remarks, AssignSales=@sales, " &
+                        "ProjectList=@projectList, " &
                         "Note=@note, ProjectDate=@projdate, " &
                         "ReferenceNumber=@refnum WHERE projectID=@id"
 
@@ -221,6 +270,7 @@ Namespace DPC.Views.Project
                         cmd.Parameters.AddWithValue("@mode", If(selectedMode, ""))
                         cmd.Parameters.AddWithValue("@remarks", If(selectedRemarks, ""))
                         cmd.Parameters.AddWithValue("@sales", If(selectedAssignSales, ""))
+                        cmd.Parameters.AddWithValue("@projectList", projectList)   ' ── NEW ──
                         cmd.Parameters.AddWithValue("@note", noteText)
                         cmd.Parameters.AddWithValue("@projdate", If(DatePicker.SelectedDate, DBNull.Value))
                         cmd.Parameters.AddWithValue("@refnum", txtReferenceNumber.Text)
@@ -244,7 +294,9 @@ Namespace DPC.Views.Project
             Return cmb.SelectedItem.ToString()
         End Function
 
-        ' ── Rich Text Editor ──
+        ' =========================================================
+        ' RICH TEXT EDITOR FORMATTING
+        ' =========================================================
         Private Sub Format_Bold_Click(sender As Object, e As RoutedEventArgs)
             EditingCommands.ToggleBold.Execute(Nothing, EditorBox)
         End Sub

--- a/Views/Project/EditProject.xaml.vb
+++ b/Views/Project/EditProject.xaml.vb
@@ -407,7 +407,7 @@ Namespace DPC.Views.Project
                     img.Stretch = Stretch.Uniform
                     Dim container As New InlineUIContainer(img, EditorBox.CaretPosition)
                 Catch ex As Exception
-                    MessageBox.Show("Unable to insert this image.", "Error", MessageBoxButton.OK, MessageBoxImage.Error)
+                    MessageBox.Show("Unable to    insert this image.", "Error", MessageBoxButton.OK, MessageBoxImage.Error)
                 End Try
             End If
         End Sub

--- a/Views/Project/ManageProject.xaml.vb
+++ b/Views/Project/ManageProject.xaml.vb
@@ -14,6 +14,7 @@ Namespace DPC.Views.Project
 
         Private _projectID As String
         Private _allProjects As List(Of DPC.Data.Model.Project)
+        Private _allProjectsTotal As List(Of DPC.Data.Model.Project)
         Private _filteredProjects As List(Of DPC.Data.Model.Project)
         Private _currentPage As Integer = 1
         Private _pageSize As Integer = 10
@@ -21,7 +22,6 @@ Namespace DPC.Views.Project
         Public Sub New()
             InitializeComponent()
             AddHandler txtSearch.TextChanged, AddressOf TxtSearch_TextChanged
-
         End Sub
 
         Private Sub UserControl_Loaded(sender As Object, e As RoutedEventArgs)
@@ -33,11 +33,13 @@ Namespace DPC.Views.Project
         ' =========================================================
         Public Sub LoadData()
             Try
+                ' Active grid list (DPC GOV SALES is the default view)
                 _allProjects = DPC.Data.Controllers.ProjectController.GetProjects()
-                If _allProjects Is Nothing Then
-                    MessageBox.Show("GetProjects returned Nothing!")
-                    _allProjects = New List(Of DPC.Data.Model.Project)()
-                End If
+                If _allProjects Is Nothing Then _allProjects = New List(Of DPC.Data.Model.Project)()
+
+                ' Combined total for the status cards — always all three lists
+                RefreshTotalForCards()
+
                 _filteredProjects = _allProjects
                 _currentPage = 1
                 ApplyPagination()
@@ -48,37 +50,46 @@ Namespace DPC.Views.Project
             End Try
         End Sub
 
-        ' =========================================================
-        ' STATUS SUMMARY CARDS
-        ' =========================================================
-        Private Sub UpdateStatusCounts()
-            Dim source = If(_allProjects, New List(Of DPC.Data.Model.Project)())
+        ' Rebuilds _allProjectsTotal from all three lists so the cards are always global
+        Private Sub RefreshTotalForCards()
+            Dim govSales = DPC.Data.Controllers.ProjectController.GetProjects()
+            Dim awarded = DPC.Data.Controllers.ProjectController.GetAwardedProjects()
+            Dim collection = DPC.Data.Controllers.ProjectController.GetCollectionData()
 
-            Dim awarded = source.Where(Function(p) String.Equals(p.Status, "AWARDED", StringComparison.OrdinalIgnoreCase)).Count()
-            Dim ongoing = source.Where(Function(p) String.Equals(p.Status, "ON-GOING", StringComparison.OrdinalIgnoreCase)).Count()
-            Dim done = source.Where(Function(p) String.Equals(p.Status, "DONE", StringComparison.OrdinalIgnoreCase)).Count()  ' ← was "COMPLETED"
-            Dim cancelled = source.Where(Function(p) String.Equals(p.Status, "CANCELLED", StringComparison.OrdinalIgnoreCase)).Count()
-
-            tbAwarded.Text = awarded.ToString()
-            tbOnGoing.Text = ongoing.ToString()
-            tbCompleted.Text = done.ToString()
-            tbCancelled.Text = cancelled.ToString()
+            _allProjectsTotal = New List(Of DPC.Data.Model.Project)()
+            If govSales IsNot Nothing Then _allProjectsTotal.AddRange(govSales)
+            If awarded IsNot Nothing Then _allProjectsTotal.AddRange(awarded)
+            If collection IsNot Nothing Then _allProjectsTotal.AddRange(collection)
         End Sub
 
         ' =========================================================
-        ' PAGE SIZE DROP-DOWN
+        ' STATUS SUMMARY CARDS  (uses _allProjectsTotal — always global)
+        ' =========================================================
+        Private Sub UpdateStatusCounts()
+            Dim source = If(_allProjectsTotal, New List(Of DPC.Data.Model.Project)())
+
+            Dim awardedCount = source.Where(Function(p) String.Equals(p.Status, "AWARDED", StringComparison.OrdinalIgnoreCase)).Count()
+            Dim ongoingCount = source.Where(Function(p) String.Equals(p.Status, "ON-GOING", StringComparison.OrdinalIgnoreCase)).Count()
+            Dim doneCount = source.Where(Function(p) String.Equals(p.Status, "DONE", StringComparison.OrdinalIgnoreCase)).Count()
+            Dim cancelledCount = source.Where(Function(p) String.Equals(p.Status, "CANCELLED", StringComparison.OrdinalIgnoreCase)).Count()
+
+            tbAwarded.Text = awardedCount.ToString()
+            tbOnGoing.Text = ongoingCount.ToString()
+            tbCompleted.Text = doneCount.ToString()
+            tbCancelled.Text = cancelledCount.ToString()
+        End Sub
+
+        ' =========================================================
+        ' PAGE SIZE DROP-DOWN  (list switcher)
         ' =========================================================
         Private Sub CmbPageSize_SelectionChanged(sender As Object, e As SelectionChangedEventArgs)
-            ' Guard: don't run if data isn't loaded yet
             If _allProjects Is Nothing Then Return
 
             Dim combo = TryCast(sender, ComboBox)
             If combo IsNot Nothing AndAlso combo.SelectedItem IsNot Nothing Then
                 Dim selectedItem = TryCast(combo.SelectedItem, ComboBoxItem)
                 If selectedItem IsNot Nothing Then
-                    Dim viewName = selectedItem.Content.ToString()
-
-                    Select Case viewName
+                    Select Case selectedItem.Content.ToString()
                         Case "DPC GOV SALES"
                             LoadDPCGovSalesData()
                         Case "AWARDED PROJECTS"
@@ -102,10 +113,7 @@ Namespace DPC.Views.Project
 
             Dim paged = _filteredProjects.Skip((_currentPage - 1) * _pageSize).Take(_pageSize).ToList()
 
-            ' ADD THIS CHECK
-            If ProjectDataGrid Is Nothing Then
-                Return
-            End If
+            If ProjectDataGrid Is Nothing Then Return
 
             ProjectDataGrid.ItemsSource = New ObservableCollection(Of DPC.Data.Model.Project)(paged)
 
@@ -173,33 +181,32 @@ Namespace DPC.Views.Project
             End If
         End Sub
 
+        ' =========================================================
+        ' LIST LOADERS
+        ' Note: RefreshTotalForCards() is NOT called here so the
+        ' card totals stay global even as the grid view changes.
+        ' =========================================================
         Private Sub LoadDPCGovSalesData()
             Try
                 _allProjects = DPC.Data.Controllers.ProjectController.GetProjects()
-                If _allProjects Is Nothing Then
-                    _allProjects = New List(Of DPC.Data.Model.Project)()
-                End If
+                If _allProjects Is Nothing Then _allProjects = New List(Of DPC.Data.Model.Project)()
                 _filteredProjects = _allProjects
                 _currentPage = 1
                 txtSearch.Text = ""
                 ApplyPagination()
-                UpdateStatusCounts()
             Catch ex As Exception
                 MessageBox.Show("Error loading DPC GOV SALES: " & ex.Message)
             End Try
         End Sub
 
-
         Private Sub LoadAwardedProjectsData()
             Try
-                ' Your logic to fetch AWARDED PROJECTS data
-                _filteredProjects = DPC.Data.Controllers.ProjectController.GetAwardedProjects()
-                If _filteredProjects Is Nothing Then
-                    _filteredProjects = New List(Of DPC.Data.Model.Project)()
-                End If
+                _allProjects = DPC.Data.Controllers.ProjectController.GetAwardedProjects()
+                If _allProjects Is Nothing Then _allProjects = New List(Of DPC.Data.Model.Project)()
+                _filteredProjects = _allProjects
                 _currentPage = 1
+                txtSearch.Text = ""
                 ApplyPagination()
-                UpdateStatusCounts()
             Catch ex As Exception
                 MessageBox.Show("Error loading AWARDED PROJECTS: " & ex.Message)
             End Try
@@ -207,22 +214,19 @@ Namespace DPC.Views.Project
 
         Private Sub LoadCollectionData()
             Try
-                ' Your logic to fetch COLLECTION data
-                _filteredProjects = DPC.Data.Controllers.ProjectController.GetCollectionData()
-                If _filteredProjects Is Nothing Then
-                    _filteredProjects = New List(Of DPC.Data.Model.Project)()
-                End If
+                _allProjects = DPC.Data.Controllers.ProjectController.GetCollectionData()
+                If _allProjects Is Nothing Then _allProjects = New List(Of DPC.Data.Model.Project)()
+                _filteredProjects = _allProjects
                 _currentPage = 1
+                txtSearch.Text = ""
                 ApplyPagination()
-                UpdateStatusCounts()
             Catch ex As Exception
                 MessageBox.Show("Error loading COLLECTION: " & ex.Message)
             End Try
         End Sub
 
-
         ' =========================================================
-        ' SEARCH
+        ' SEARCH  (searches within the active list only)
         ' =========================================================
         Private Sub TxtSearch_TextChanged(sender As Object, e As TextChangedEventArgs)
             If _allProjects Is Nothing Then Return
@@ -246,7 +250,6 @@ Namespace DPC.Views.Project
 
             _currentPage = 1
             ApplyPagination()
-            UpdateStatusCounts()
         End Sub
 
         ' =========================================================
@@ -291,6 +294,8 @@ Namespace DPC.Views.Project
                     End Using
                 End Using
                 ProjectDataGrid.ItemsSource = Nothing
+
+                ' Reload everything so cards stay accurate after a delete
                 LoadData()
             Catch ex As Exception
                 MessageBox.Show("Error deleting project: " & ex.Message)

--- a/Views/Project/ManageProject.xaml.vb
+++ b/Views/Project/ManageProject.xaml.vb
@@ -174,12 +174,21 @@ Namespace DPC.Views.Project
         End Sub
 
         Private Sub LoadDPCGovSalesData()
-            _filteredProjects = _allProjects
-            _currentPage = 1
-            txtSearch.Text = ""
-            ApplyPagination()
-            UpdateStatusCounts()
+            Try
+                _allProjects = DPC.Data.Controllers.ProjectController.GetProjects()
+                If _allProjects Is Nothing Then
+                    _allProjects = New List(Of DPC.Data.Model.Project)()
+                End If
+                _filteredProjects = _allProjects
+                _currentPage = 1
+                txtSearch.Text = ""
+                ApplyPagination()
+                UpdateStatusCounts()
+            Catch ex As Exception
+                MessageBox.Show("Error loading DPC GOV SALES: " & ex.Message)
+            End Try
         End Sub
+
 
         Private Sub LoadAwardedProjectsData()
             Try

--- a/data/Controllers/ProjectController.vb
+++ b/data/Controllers/ProjectController.vb
@@ -5,6 +5,39 @@ Namespace DPC.Data.Controllers
     Public Class ProjectController
 
         ' =========================================================
+        ' MAPPER HELPER
+        ' Central place that converts a reader row → Project model.
+        ' All Read methods call this so ProjectList is never missed.
+        ' =========================================================
+        Private Shared Function MapProject(reader As MySqlDataReader) As DPC.Data.Model.Project
+            Return New DPC.Data.Model.Project With {
+                .ProjectID = Convert.ToInt32(reader("ProjectID")),
+                .ProjectDate = If(IsDBNull(reader("ProjectDate")), Nothing, CType(reader("ProjectDate"), DateTime?)),
+                .ReferenceNumber = If(IsDBNull(reader("ReferenceNumber")), "", reader("ReferenceNumber").ToString()),
+                .ProjectTitle = If(IsDBNull(reader("ProjectTitle")), "", reader("ProjectTitle").ToString()),
+                .Category = If(IsDBNull(reader("Category")), "", reader("Category").ToString()),
+                .ProjectType = If(IsDBNull(reader("ProjectType")), "", reader("ProjectType").ToString()),
+                .ContactPerson = If(IsDBNull(reader("ContactPerson")), "", reader("ContactPerson").ToString()),
+                .ContactNumber = If(IsDBNull(reader("ContactNumber")), "", reader("ContactNumber").ToString()),
+                .EmailAddress = If(IsDBNull(reader("EmailAddress")), "", reader("EmailAddress").ToString()),
+                .AreaOfDelivery = If(IsDBNull(reader("AreaOfDelivery")), "", reader("AreaOfDelivery").ToString()),
+                .PreBidDate = If(IsDBNull(reader("PreBidDate")), Nothing, CType(reader("PreBidDate"), DateTime?)),
+                .ClosingDate = If(IsDBNull(reader("ClosingDate")), Nothing, CType(reader("ClosingDate"), DateTime?)),
+                .ABC = If(IsDBNull(reader("ABC")), 0L, Convert.ToInt64(reader("ABC"))),
+                .BidRFQOffer = If(IsDBNull(reader("BidRFQOffer")), 0L, Convert.ToInt64(reader("BidRFQOffer"))),
+                .ReceiveDate = If(IsDBNull(reader("ReceiveDate")), Nothing, CType(reader("ReceiveDate"), DateTime?)),
+                .ModeOfSubmission = If(IsDBNull(reader("ModeOfSubmission")), "", reader("ModeOfSubmission").ToString()),
+                .Status = If(IsDBNull(reader("Status")), "", reader("Status").ToString()),
+                .Remarks = If(IsDBNull(reader("Remarks")), "", reader("Remarks").ToString()),
+                .AssignSales = If(IsDBNull(reader("AssignSales")), "", reader("AssignSales").ToString()),
+                .ProjectList = If(IsDBNull(reader("ProjectList")), "DPC_GOV_SALES", reader("ProjectList").ToString()),
+                .Note = If(IsDBNull(reader("Note")), "", reader("Note").ToString()),
+                .CreatedAt = If(IsDBNull(reader("CreatedAt")), Nothing, CType(reader("CreatedAt"), DateTime?)),
+                .UpdatedAt = If(IsDBNull(reader("UpdatedAt")), Nothing, CType(reader("UpdatedAt"), DateTime?))
+            }
+        End Function
+
+        ' =========================================================
         ' CREATE
         ' =========================================================
         Public Shared Function CreateProject(proj As DPC.Data.Model.Project) As Boolean
@@ -13,13 +46,13 @@ Namespace DPC.Data.Controllers
                 "  ProjectDate, ReferenceNumber, ProjectTitle, Category, ProjectType, " &
                 "  ContactPerson, ContactNumber, EmailAddress, AreaOfDelivery, " &
                 "  PreBidDate, ClosingDate, ABC, BidRFQOffer, ReceiveDate, " &
-                "  ModeOfSubmission, Status, Remarks, AssignSales, Note, " &
+                "  ModeOfSubmission, Status, Remarks, AssignSales, ProjectList, Note, " &
                 "  CreatedAt, UpdatedAt" &
                 ") VALUES (" &
                 "  @ProjectDate, @ReferenceNumber, @ProjectTitle, @Category, @ProjectType, " &
                 "  @ContactPerson, @ContactNumber, @EmailAddress, @AreaOfDelivery, " &
                 "  @PreBidDate, @ClosingDate, @ABC, @BidRFQOffer, @ReceiveDate, " &
-                "  @ModeOfSubmission, @Status, @Remarks, @AssignSales, @Note, " &
+                "  @ModeOfSubmission, @Status, @Remarks, @AssignSales, @ProjectList, @Note, " &
                 "  @CreatedAt, @UpdatedAt" &
                 ")"
 
@@ -45,6 +78,7 @@ Namespace DPC.Data.Controllers
                         cmd.Parameters.AddWithValue("@Status", If(String.IsNullOrWhiteSpace(proj.Status), DBNull.Value, proj.Status))
                         cmd.Parameters.AddWithValue("@Remarks", If(String.IsNullOrWhiteSpace(proj.Remarks), DBNull.Value, proj.Remarks))
                         cmd.Parameters.AddWithValue("@AssignSales", If(String.IsNullOrWhiteSpace(proj.AssignSales), DBNull.Value, proj.AssignSales))
+                        cmd.Parameters.AddWithValue("@ProjectList", If(String.IsNullOrWhiteSpace(proj.ProjectList), "DPC_GOV_SALES", proj.ProjectList))
                         cmd.Parameters.AddWithValue("@Note", If(String.IsNullOrWhiteSpace(proj.Note), DBNull.Value, proj.Note))
                         cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now)
                         cmd.Parameters.AddWithValue("@UpdatedAt", DateTime.Now)
@@ -61,18 +95,14 @@ Namespace DPC.Data.Controllers
         End Function
 
         ' =========================================================
-        ' READ ALL
+        ' READ — DPC GOV SALES (default list)
         ' =========================================================
         Public Shared Function GetProjects() As List(Of DPC.Data.Model.Project)
             Dim results As New List(Of DPC.Data.Model.Project)()
 
             Dim query As String =
-                "SELECT ProjectID, ProjectDate, ReferenceNumber, ProjectTitle, " &
-                "       Category, ProjectType, ContactPerson, ContactNumber, " &
-                "       EmailAddress, AreaOfDelivery, PreBidDate, ClosingDate, " &
-                "       ABC, BidRFQOffer, ReceiveDate, ModeOfSubmission, " &
-                "       Status, Remarks, AssignSales, Note, CreatedAt, UpdatedAt " &
-                "FROM project " &
+                "SELECT * FROM project " &
+                "WHERE ProjectList = 'DPC_GOV_SALES' " &
                 "ORDER BY ProjectID DESC"
 
             Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
@@ -81,35 +111,72 @@ Namespace DPC.Data.Controllers
                     Using cmd As New MySqlCommand(query, conn)
                         Using reader As MySqlDataReader = cmd.ExecuteReader()
                             While reader.Read()
-                                results.Add(New DPC.Data.Model.Project With {
-                                    .ProjectID = Convert.ToInt32(reader("ProjectID")),
-                                    .ProjectDate = If(IsDBNull(reader("ProjectDate")), Nothing, CType(reader("ProjectDate"), DateTime?)),
-                                    .ReferenceNumber = If(IsDBNull(reader("ReferenceNumber")), "", reader("ReferenceNumber").ToString()),
-                                    .ProjectTitle = If(IsDBNull(reader("ProjectTitle")), "", reader("ProjectTitle").ToString()),
-                                    .Category = If(IsDBNull(reader("Category")), "", reader("Category").ToString()),
-                                    .ProjectType = If(IsDBNull(reader("ProjectType")), "", reader("ProjectType").ToString()),
-                                    .ContactPerson = If(IsDBNull(reader("ContactPerson")), "", reader("ContactPerson").ToString()),
-                                    .ContactNumber = If(IsDBNull(reader("ContactNumber")), "", reader("ContactNumber").ToString()),
-                                    .EmailAddress = If(IsDBNull(reader("EmailAddress")), "", reader("EmailAddress").ToString()),
-                                    .AreaOfDelivery = If(IsDBNull(reader("AreaOfDelivery")), "", reader("AreaOfDelivery").ToString()),
-                                    .PreBidDate = If(IsDBNull(reader("PreBidDate")), Nothing, CType(reader("PreBidDate"), DateTime?)),
-                                    .ClosingDate = If(IsDBNull(reader("ClosingDate")), Nothing, CType(reader("ClosingDate"), DateTime?)),
-                                    .ABC = If(IsDBNull(reader("ABC")), 0L, Convert.ToInt64(reader("ABC"))),
-                                    .BidRFQOffer = If(IsDBNull(reader("BidRFQOffer")), 0L, Convert.ToInt64(reader("BidRFQOffer"))),
-                                    .ReceiveDate = If(IsDBNull(reader("ReceiveDate")), Nothing, CType(reader("ReceiveDate"), DateTime?)),
-                                    .ModeOfSubmission = If(IsDBNull(reader("ModeOfSubmission")), "", reader("ModeOfSubmission").ToString()),
-                                    .Status = If(IsDBNull(reader("Status")), "", reader("Status").ToString()),
-                                    .Remarks = If(IsDBNull(reader("Remarks")), "", reader("Remarks").ToString()),
-                                    .AssignSales = If(IsDBNull(reader("AssignSales")), "", reader("AssignSales").ToString()),
-                                    .Note = If(IsDBNull(reader("Note")), "", reader("Note").ToString()),
-                                    .CreatedAt = If(IsDBNull(reader("CreatedAt")), Nothing, CType(reader("CreatedAt"), DateTime?)),
-                                    .UpdatedAt = If(IsDBNull(reader("UpdatedAt")), Nothing, CType(reader("UpdatedAt"), DateTime?))
-                                })
+                                results.Add(MapProject(reader))
                             End While
                         End Using
                     End Using
                 Catch ex As Exception
                     MessageBox.Show("Error loading projects: " & ex.Message,
+                                    "Database Error", MessageBoxButton.OK, MessageBoxImage.Error)
+                End Try
+            End Using
+
+            Return results
+        End Function
+
+        ' =========================================================
+        ' READ — AWARDED PROJECTS
+        ' =========================================================
+        Public Shared Function GetAwardedProjects() As List(Of DPC.Data.Model.Project)
+            Dim results As New List(Of DPC.Data.Model.Project)()
+
+            Dim query As String =
+                "SELECT * FROM project " &
+                "WHERE ProjectList = 'AWARDED_PROJECTS' " &
+                "ORDER BY ProjectID DESC"
+
+            Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
+                Try
+                    conn.Open()
+                    Using cmd As New MySqlCommand(query, conn)
+                        Using reader As MySqlDataReader = cmd.ExecuteReader()
+                            While reader.Read()
+                                results.Add(MapProject(reader))
+                            End While
+                        End Using
+                    End Using
+                Catch ex As Exception
+                    MessageBox.Show("Error loading awarded projects: " & ex.Message,
+                                    "Database Error", MessageBoxButton.OK, MessageBoxImage.Error)
+                End Try
+            End Using
+
+            Return results
+        End Function
+
+        ' =========================================================
+        ' READ — COLLECTION
+        ' =========================================================
+        Public Shared Function GetCollectionData() As List(Of DPC.Data.Model.Project)
+            Dim results As New List(Of DPC.Data.Model.Project)()
+
+            Dim query As String =
+                "SELECT * FROM project " &
+                "WHERE ProjectList = 'COLLECTION' " &
+                "ORDER BY ProjectID DESC"
+
+            Using conn As MySqlConnection = SplashScreen.GetDatabaseConnection()
+                Try
+                    conn.Open()
+                    Using cmd As New MySqlCommand(query, conn)
+                        Using reader As MySqlDataReader = cmd.ExecuteReader()
+                            While reader.Read()
+                                results.Add(MapProject(reader))
+                            End While
+                        End Using
+                    End Using
+                Catch ex As Exception
+                    MessageBox.Show("Error loading collection data: " & ex.Message,
                                     "Database Error", MessageBoxButton.OK, MessageBoxImage.Error)
                 End Try
             End Using
@@ -141,6 +208,7 @@ Namespace DPC.Data.Controllers
                 "  Status            = @Status, " &
                 "  Remarks           = @Remarks, " &
                 "  AssignSales       = @AssignSales, " &
+                "  ProjectList       = @ProjectList, " &
                 "  Note              = @Note, " &
                 "  UpdatedAt         = @UpdatedAt " &
                 "WHERE ProjectID = @ProjectID"
@@ -168,6 +236,7 @@ Namespace DPC.Data.Controllers
                         cmd.Parameters.AddWithValue("@Status", If(String.IsNullOrWhiteSpace(proj.Status), DBNull.Value, proj.Status))
                         cmd.Parameters.AddWithValue("@Remarks", If(String.IsNullOrWhiteSpace(proj.Remarks), DBNull.Value, proj.Remarks))
                         cmd.Parameters.AddWithValue("@AssignSales", If(String.IsNullOrWhiteSpace(proj.AssignSales), DBNull.Value, proj.AssignSales))
+                        cmd.Parameters.AddWithValue("@ProjectList", If(String.IsNullOrWhiteSpace(proj.ProjectList), "DPC_GOV_SALES", proj.ProjectList))
                         cmd.Parameters.AddWithValue("@Note", If(String.IsNullOrWhiteSpace(proj.Note), DBNull.Value, proj.Note))
                         cmd.Parameters.AddWithValue("@UpdatedAt", DateTime.Now)
 
@@ -201,20 +270,6 @@ Namespace DPC.Data.Controllers
                 End Try
             End Using
         End Function
-
-        Public Shared Function GetDPCGovSalesProjects() As List(Of DPC.Data.Model.Project)
-            ' Your database query logic for DPC GOV SALES
-        End Function
-
-        Public Shared Function GetAwardedProjects() As List(Of DPC.Data.Model.Project)
-            ' Your database query logic for AWARDED PROJECTS
-        End Function
-
-        Public Shared Function GetCollectionData() As List(Of DPC.Data.Model.Project)
-            ' Your database query logic for COLLECTION
-        End Function
-
-
 
     End Class
 End Namespace

--- a/data/models/Project.vb
+++ b/data/models/Project.vb
@@ -40,5 +40,8 @@
         Public Property CreatedAt As DateTime?
         Public Property UpdatedAt As DateTime?
 
+        ' ── ETC ───────────────────────────────────────────
+        Public Property ProjectList As String = "DPC_GOV_SALES"
+
     End Class
 End Namespace


### PR DESCRIPTION
### **DONE**
- Data on DPC GOV SALES can now be routed to AWARDED PROJECTS or COLLECTION at creation or edit
- Status cards are globally scoped — aggregates counts across all three lists regardless of the active grid view