### PR TITLE
Refined Stock Deduction

### DIFF
--- a/Components/Forms/UniversalPrintablePreviewDocument.xaml.vb
+++ b/Components/Forms/UniversalPrintablePreviewDocument.xaml.vb
@@ -419,12 +419,18 @@ Namespace DPC.Components.Forms
                             End Using
 
                             ' Calculate new stock
-                            Dim newStock As Integer = currentStock - quantitySold
+                            Dim deductedStock As Integer = currentStock - quantitySold
+                            Dim newStock As Integer = Math.Max(deductedStock, 0)
+
+                            If quantitySold > currentStock Then
+                                Debug.WriteLine("WARNING: Quantity to deduct is greater than current stock for product " & productID &
+                    ". Current stock: " & currentStock & ", requested deduction: " & quantitySold &
+                    ". Stock will be set to 0.")
+                            End If
+
                             Debug.WriteLine("New stock will be: " & newStock)
 
-                            ' Update stock
                             Dim updateStockQuery As String = "UPDATE " & tableToUpdate & " SET stockUnit = @newStock, dateModified = NOW() WHERE productID = @productID"
-
                             Using cmd As New MySqlCommand(updateStockQuery, conn)
                                 cmd.Parameters.AddWithValue("@newStock", newStock)
                                 cmd.Parameters.AddWithValue("@productID", productID)

--- a/Views/Stocks/ItemManager/ProductManager/ManageProducts.xaml.vb
+++ b/Views/Stocks/ItemManager/ProductManager/ManageProducts.xaml.vb
@@ -163,7 +163,7 @@ Namespace DPC.Views.Stocks.ItemManager.ProductManager
                             b.brandName AS Brand,  
                             s.supplierName AS Supplier,  
                             GROUP_CONCAT(DISTINCT WarehouseFiltered.warehouseName SEPARATOR ', ') AS Warehouse,  
-                            SUM(COALESCE(pnv.stockUnit, 0) + COALESCE(pvs.stockUnit, 0)) AS StockQuantity,  
+                            GREATEST(SUM(COALESCE(pnv.stockUnit, 0) + COALESCE(pvs.stockUnit, 0)), 0) AS StockQuantity,  
                             MAX(COALESCE(pnv.alertQuantity, pvs.alertQuantity, 0)) AS AlertQuantity,  
                             MAX(COALESCE(pnv.buyingPrice, pvs.buyingPrice, 0)) AS BuyingPrice,
                             MAX(COALESCE(pnv.sellingPrice, pvs.sellingPrice, 0)) AS SellingPrice,
@@ -265,7 +265,16 @@ Namespace DPC.Views.Stocks.ItemManager.ProductManager
 
                         ' Clear warehouse for out-of-stock products
                         Dim stockQuantity As Integer = Convert.ToInt32(row("StockQuantity"))
-                        If stockQuantity = 0 Then
+
+                        If stockQuantity < 0 Then
+                            stockQuantity = 0
+                            row("StockQuantity") = 0
+                        End If
+
+                        If stockQuantity > 0 Then
+                            inStockProducts += 1
+                        Else
+                            stockOutProducts += 1
                             row("Warehouse") = DBNull.Value
                         End If
                     Next


### PR DESCRIPTION
Changes:

Currently the stock quantity of products turns negative numbers (e.g. -1, -2) it shouldn't be that way. 

The new deduction in stocks now only remains in 0 value.